### PR TITLE
Add ability to remove headers in routing staticHeaders

### DIFF
--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
@@ -212,7 +212,12 @@ public class Forwarder implements Handler<RoutingContext> {
     private void setStaticHeaders(HttpClientRequest cReq) {
         if (rule.getStaticHeaders() != null) {
             for (Map.Entry<String, String> entry : rule.getStaticHeaders().entrySet()) {
-                cReq.headers().set(entry.getKey(), entry.getValue());
+                String entryValue = entry.getValue();
+                if (entryValue != null && entryValue.length() >0 && !entryValue.equalsIgnoreCase("null")) {
+                    cReq.headers().set(entry.getKey(), entry.getValue());
+                } else {
+                    cReq.headers().remove(entry.getKey());
+                }
             }
         }
     }

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
@@ -213,7 +213,7 @@ public class Forwarder implements Handler<RoutingContext> {
         if (rule.getStaticHeaders() != null) {
             for (Map.Entry<String, String> entry : rule.getStaticHeaders().entrySet()) {
                 String entryValue = entry.getValue();
-                if (entryValue != null && entryValue.length() >0 && !entryValue.equalsIgnoreCase("null")) {
+                if (entryValue != null && entryValue.length() > 0 ) {
                     cReq.headers().set(entry.getKey(), entry.getValue());
                 } else {
                     cReq.headers().remove(entry.getKey());

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/routing/StaticHeaderTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/routing/StaticHeaderTest.java
@@ -1,0 +1,114 @@
+package org.swisspush.gateleen.routing;
+
+import com.fasterxml.jackson.databind.util.JSONPObject;
+import com.google.common.collect.ImmutableMap;
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.http.ContentType;
+import com.jayway.restassured.response.Response;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.swisspush.gateleen.AbstractTest;
+import org.swisspush.gateleen.TestUtils;
+
+import java.io.File;
+
+import static com.jayway.restassured.RestAssured.*;
+
+@RunWith(VertxUnitRunner.class)
+public class StaticHeaderTest extends AbstractTest {
+
+	/**
+	 * Overwrite RestAssured configuration
+	 */
+	public void initRestAssured() {
+		super.initRestAssured();
+		RestAssured.requestSpecification.basePath(SERVER_ROOT + "/pages");
+	}
+
+	public void init(){
+		delete();
+
+		// add a routing
+		JsonObject rules = new JsonObject();
+		rules = TestUtils.addRoutingRuleMainStorage(rules);
+		rules = createStaticHeaderRules(rules);
+		TestUtils.putRoutingRules(rules);
+
+	}
+
+	public JsonObject createStaticHeaderRules(JsonObject rules){
+		JsonObject header = new JsonObject();
+		JsonObject nullObj = null;
+		header.put("x-queue", "position");
+		header.put("x-expire-after", "30");
+		header.put("x-flow-control-window", "5");
+		header.put("notpresentheaderelement", "null" );
+
+		JsonObject translate = new JsonObject();
+		translate.put("202",200);
+
+		JsonObject test1Rule =  TestUtils.createRoutingRule(ImmutableMap.of(
+				"description",
+				"Adding static headers with null values",
+				"translateStatus",
+				translate,
+				"staticHeaders",
+				header,
+				"url",
+				"http://localhost:" + MAIN_PORT + ROOT + "/debug"
+		));
+		String ruleName = SERVER_ROOT + "/pages/test/test1";
+		rules = TestUtils.addRoutingRule(rules, ruleName, test1Rule);
+
+		header.put("presentheaderelement", "notnull");
+		JsonObject test2Rule =  TestUtils.createRoutingRule(ImmutableMap.of(
+				"description",
+				"Adding static headers without null values",
+				"translateStatus",
+				translate,
+				"staticHeaders",
+				header,
+				"url",
+				"http://localhost:" + MAIN_PORT + ROOT + "/debug"
+		));
+		ruleName = SERVER_ROOT + "/pages/test/test2";
+		rules = TestUtils.addRoutingRule(rules, ruleName, test2Rule);
+
+		return rules;
+	}
+
+	/**
+	 * Test if static header which contains null values are removed from request
+	 */
+	@Test
+	public void testStaticHeaderWithNullValue(TestContext context){
+		Async async = context.async();
+		delete();
+		init();
+		String body = with().get("/test/test1").getBody().asString();
+		System.out.println(body);
+		Assert.assertFalse(body.contains("notpresentheaderelement"));
+		async.complete();
+	}
+
+	/**
+	 * Test if static header are set if it does not contain null values
+	 */
+	@Test
+	public void testStaticHeaderWithNoNullValue(TestContext context){
+		Async async = context.async();
+		delete();
+		init();
+		String body = with().get("/test/test2").getBody().asString();
+		System.out.println(body);
+		Assert.assertTrue(body.contains("presentheaderelement"));
+		async.complete();
+	}
+
+}

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/routing/StaticHeaderTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/routing/StaticHeaderTest.java
@@ -1,11 +1,7 @@
 package org.swisspush.gateleen.routing;
 
-import com.fasterxml.jackson.databind.util.JSONPObject;
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.http.ContentType;
-import com.jayway.restassured.response.Response;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -15,8 +11,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.swisspush.gateleen.AbstractTest;
 import org.swisspush.gateleen.TestUtils;
-
-import java.io.File;
 
 import static com.jayway.restassured.RestAssured.*;
 
@@ -44,11 +38,10 @@ public class StaticHeaderTest extends AbstractTest {
 
 	public JsonObject createStaticHeaderRules(JsonObject rules){
 		JsonObject header = new JsonObject();
-		JsonObject nullObj = null;
 		header.put("x-queue", "position");
 		header.put("x-expire-after", "30");
 		header.put("x-flow-control-window", "5");
-		header.put("notpresentheaderelement", "null" );
+		header.put("notpresentheaderelement", "");
 
 		JsonObject translate = new JsonObject();
 		translate.put("202",200);
@@ -91,7 +84,7 @@ public class StaticHeaderTest extends AbstractTest {
 		Async async = context.async();
 		delete();
 		init();
-		String body = with().get("/test/test1").getBody().asString();
+		String body = with().header("notpresentheaderelement", "value").get("/test/test1").getBody().asString();
 		System.out.println(body);
 		Assert.assertFalse(body.contains("notpresentheaderelement"));
 		async.complete();
@@ -111,4 +104,17 @@ public class StaticHeaderTest extends AbstractTest {
 		async.complete();
 	}
 
+	/**
+	 * Test if static header are set if it does not contain null values
+	 */
+	@Test
+	public void testStaticHeaderOverwrite(TestContext context){
+		Async async = context.async();
+		delete();
+		init();
+		String body = with().header("presentheaderelement", "value").get("/test/test2").getBody().asString();
+		System.out.println(body);
+		Assert.assertTrue(body.contains("presentheaderelement: notnull"));
+		async.complete();
+	}
 }


### PR DESCRIPTION
setting
"staticHeaders": {
  "x-server-timestamp": ""
}
removes the header
