### PR TITLE
Exclude dependency to c3p0 (a JDBC connection pool implementation).

### DIFF
--- a/gateleen-scheduler/pom.xml
+++ b/gateleen-scheduler/pom.xml
@@ -42,6 +42,12 @@
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>c3p0</groupId>
+                    <artifactId>c3p0</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Gateleen does not use JDBC at all.