### PR TITLE
Support hooking on other servers in javascript 

### DIFF
--- a/gateleen-hook-js/src/main/webapp/app/js/gateleen-hook.js
+++ b/gateleen-hook-js/src/main/webapp/app/js/gateleen-hook.js
@@ -39,7 +39,8 @@
             if (/\/$/.test(path)) {
                 path = path.slice(0, -1);
             }
-            context = '/' + path.split('/')[1];
+            var match = /(.*:\/\/.+?)?\/.+?\//.exec(path);
+            context = match[0].substring(0, match[0].length - 1);
             var queue;
             if (options && options.fetch) {
                 queue = [];

--- a/gateleen-hook-js/src/test/javascript/hook/gateleen-hook.test.js
+++ b/gateleen-hook-js/src/test/javascript/hook/gateleen-hook.test.js
@@ -53,16 +53,30 @@ describe('hook', function(){
       eventBus.onopen();
       expect(eventBus.registerHandler).toHaveBeenCalled();
     });
-    it('should create the hook with HTTP PUT', function(){
+    it('should create the hook with HTTP PUT from context path', function(){
       $httpBackend.expectPUT('/context/path/_hooks/listeners/http/gateleen-hook-js-0123',
         {
           'methods':['PUT', 'POST' ],
           'destination':'/context/server/event/v1/channels/gateleen-hook-js-0123',
           'expireAfter':10,
           'staticHeaders':{'x-queue-mode':'transient'}
-    }
+        }
       ).respond(200,'OK');
       Hook.listen('/context/path', function() {});
+      $httpBackend.flush();
+      $httpBackend.verifyNoOutstandingExpectation();
+      $httpBackend.verifyNoOutstandingRequest();
+    });
+    it('should create the hook with HTTP PUT from complete URL', function(){
+      $httpBackend.expectPUT('http://server/context/path/_hooks/listeners/http/gateleen-hook-js-0123',
+        {
+          'methods':['PUT', 'POST' ],
+          'destination':'/context/server/event/v1/channels/gateleen-hook-js-0123',
+          'expireAfter':10,
+          'staticHeaders':{'x-queue-mode':'transient'}
+        }
+      ).respond(200,'OK');
+      Hook.listen('http://server/context/path', function() {});
       $httpBackend.flush();
       $httpBackend.verifyNoOutstandingExpectation();
       $httpBackend.verifyNoOutstandingRequest();


### PR DESCRIPTION
Until now, js hooks could only be registered on the same server `Hook.listen('/eagle/bla')`
Hooking on other servers should be supported `Hook.listen('http://server/eagle/bla')`