### PR TITLE
[ISAGD-4215] Dont Forward 'Connection' headers.

### DIFF
--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
@@ -18,8 +18,8 @@ public class HttpHeaderUtil {
      * @param headers
      *      The headers to check.
      */
-    public <T extends MultiMap> T removeNonForwardHeaders( T headers ) {
-        final String CONNECTION = HttpRequestHeader.CONECTION.getName();
+    public static <T extends MultiMap> T removeNonForwardHeaders( T headers ) {
+        final String CONNECTION = HttpRequestHeader.CONNECTION.getName();
 
         // Remove all headers named by connection-token.
         headers.getAll(CONNECTION).forEach(headers::remove);

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
@@ -1,0 +1,33 @@
+package org.swisspush.gateleen.core.util;
+
+import io.vertx.core.MultiMap;
+
+
+public class HttpHeaderUtil {
+
+    /**
+     * <p>Removes headers which MUST NOT be forwarded by proxies.</p>
+     *
+     * <ul>
+     *     <li>This MAY modifies the passed headers.</li>
+     *     <li>This MAY returns the same (modified) instance as passed.</li>
+     * </ul>
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc2616#section-14.10">RFC 2616 section 14.10</a>
+     *
+     * @param headers
+     *      The headers to check.
+     */
+    public <T extends MultiMap> T removeNonForwardHeaders( T headers ) {
+        final String CONNECTION = HttpRequestHeader.CONECTION.getName();
+
+        // Remove all headers named by connection-token.
+        headers.getAll(CONNECTION).forEach(headers::remove);
+
+        // Remove the connection headers itself.
+        headers.remove(CONNECTION);
+
+        return headers;
+    }
+
+}

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpRequestHeader.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpRequestHeader.java
@@ -8,6 +8,7 @@ import io.vertx.core.MultiMap;
  * @author https://github.com/mcweba [Marc-Andre Weber]
  */
 public enum HttpRequestHeader {
+    CONECTION("connection"),
     CONTENT_LENGTH("Content-Length"),
     X_HOPS("x-hops");
 

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpRequestHeader.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpRequestHeader.java
@@ -8,7 +8,7 @@ import io.vertx.core.MultiMap;
  * @author https://github.com/mcweba [Marc-Andre Weber]
  */
 public enum HttpRequestHeader {
-    CONECTION("connection"),
+    CONNECTION("connection"),
     CONTENT_LENGTH("Content-Length"),
     X_HOPS("x-hops");
 

--- a/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/HttpHeaderUtilTest.java
+++ b/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/HttpHeaderUtilTest.java
@@ -10,13 +10,10 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class HttpHeaderUtilTest {
 
-    private static String CONNECTION = HttpRequestHeader.CONECTION.getName();
+    private static String CONNECTION = HttpRequestHeader.CONNECTION.getName();
 
     @Test
     public void removeNonForwardHeadersTest(TestContext testContext) {
-
-        // Prepare instance to test
-        final HttpHeaderUtil httpHeaderUtil = new HttpHeaderUtil();
 
         // Mock an example header
         CaseInsensitiveHeaders headers = new CaseInsensitiveHeaders();
@@ -29,7 +26,7 @@ public class HttpHeaderUtilTest {
         headers.add("three", "other stuff");
 
         // Apply filter
-        headers = httpHeaderUtil.removeNonForwardHeaders(headers);
+        headers = HttpHeaderUtil.removeNonForwardHeaders(headers);
 
         // Assert unrelated still exists
         testContext.assertTrue(headers.contains("an-unrelated-one"));

--- a/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/HttpHeaderUtilTest.java
+++ b/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/HttpHeaderUtilTest.java
@@ -1,0 +1,47 @@
+package org.swisspush.gateleen.core.util;
+
+import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(VertxUnitRunner.class)
+public class HttpHeaderUtilTest {
+
+    private static String CONNECTION = HttpRequestHeader.CONECTION.getName();
+
+    @Test
+    public void removeNonForwardHeadersTest(TestContext testContext) {
+
+        // Prepare instance to test
+        final HttpHeaderUtil httpHeaderUtil = new HttpHeaderUtil();
+
+        // Mock an example header
+        CaseInsensitiveHeaders headers = new CaseInsensitiveHeaders();
+        headers.add(CONNECTION, "one" );
+        headers.add(CONNECTION, "two" );
+        headers.add(CONNECTION, "three" );
+        headers.add("an-unrelated-one", "123");
+        headers.add("another-unrelated", "close");
+        headers.add("one", "stuff");
+        headers.add("three", "other stuff");
+
+        // Apply filter
+        headers = httpHeaderUtil.removeNonForwardHeaders(headers);
+
+        // Assert unrelated still exists
+        testContext.assertTrue(headers.contains("an-unrelated-one"));
+        testContext.assertTrue(headers.contains("another-unrelated"));
+
+        // Assert non forwards are removed.
+        testContext.assertFalse(headers.contains(CONNECTION));
+        testContext.assertFalse(headers.contains("one"));
+        testContext.assertFalse(headers.contains("three"));
+
+        // Assert there are exactly the two valid remaining.
+        testContext.assertEquals(2, headers.size());
+    }
+
+}

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
@@ -1,5 +1,6 @@
 package org.swisspush.gateleen.hook;
 
+import org.swisspush.gateleen.core.util.HttpHeaderUtil;
 import org.swisspush.gateleen.logging.LoggingResourceManager;
 import org.swisspush.gateleen.monitoring.MonitoringHandler;
 import org.swisspush.gateleen.core.storage.ResourceStorage;
@@ -38,6 +39,7 @@ public class Route {
     private static Pattern URL_PARSE_PATTERN = Pattern.compile("^(?<scheme>https?)://(?<host>[^/:]+)(:(?<port>[0-9]+))?(?<path>/.*)$");
     private static Logger LOG = LoggerFactory.getLogger(Route.class);
 
+    private final HttpHeaderUtil httpHeaderUtil = new HttpHeaderUtil();
     private Vertx vertx;
     private LoggingResourceManager loggingResourceManager;
     private MonitoringHandler monitoringHandler;
@@ -84,7 +86,7 @@ public class Route {
      * Creates the forwarder for this hook.
      */
     private void createForwarder() {
-        forwarder = new Forwarder(vertx, client, rule, storage, loggingResourceManager, monitoringHandler, userProfilePath);
+        forwarder = new Forwarder(vertx, client, rule, storage, loggingResourceManager, monitoringHandler, userProfilePath, httpHeaderUtil);
     }
 
     /**

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
@@ -1,12 +1,5 @@
 package org.swisspush.gateleen.hook;
 
-import org.swisspush.gateleen.core.util.HttpHeaderUtil;
-import org.swisspush.gateleen.logging.LoggingResourceManager;
-import org.swisspush.gateleen.monitoring.MonitoringHandler;
-import org.swisspush.gateleen.core.storage.ResourceStorage;
-import org.swisspush.gateleen.routing.Forwarder;
-import org.swisspush.gateleen.routing.Rule;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
@@ -14,6 +7,11 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServerRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.swisspush.gateleen.core.storage.ResourceStorage;
+import org.swisspush.gateleen.logging.LoggingResourceManager;
+import org.swisspush.gateleen.monitoring.MonitoringHandler;
+import org.swisspush.gateleen.routing.Forwarder;
+import org.swisspush.gateleen.routing.Rule;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -39,7 +37,6 @@ public class Route {
     private static Pattern URL_PARSE_PATTERN = Pattern.compile("^(?<scheme>https?)://(?<host>[^/:]+)(:(?<port>[0-9]+))?(?<path>/.*)$");
     private static Logger LOG = LoggerFactory.getLogger(Route.class);
 
-    private final HttpHeaderUtil httpHeaderUtil = new HttpHeaderUtil();
     private Vertx vertx;
     private LoggingResourceManager loggingResourceManager;
     private MonitoringHandler monitoringHandler;
@@ -86,7 +83,7 @@ public class Route {
      * Creates the forwarder for this hook.
      */
     private void createForwarder() {
-        forwarder = new Forwarder(vertx, client, rule, storage, loggingResourceManager, monitoringHandler, userProfilePath, httpHeaderUtil);
+        forwarder = new Forwarder(vertx, client, rule, storage, loggingResourceManager, monitoringHandler, userProfilePath);
     }
 
     /**

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Router.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Router.java
@@ -44,6 +44,7 @@ public class Router implements Refreshable, LoggableResource, ConfigurationResou
     public static final String ROUTER_STATE_MAP = "router_state_map";
     public static final String ROUTER_BROKEN_KEY = "router_broken";
     public static final String REQUEST_HOPS_LIMIT_PROPERTY = "request.hops.limit";
+    private final HttpHeaderUtil httpHeaderUtil = new HttpHeaderUtil();
     private String rulesUri;
     private String userProfileUri;
     private String serverUri;
@@ -358,9 +359,9 @@ public class Router implements Refreshable, LoggableResource, ConfigurationResou
             } else if (rule.getStorage() != null) {
                 forwarder = new StorageForwarder(vertx.eventBus(), rule, loggingResourceManager, monitoringHandler);
             } else if (rule.getScheme().equals("local")) {
-                forwarder = new Forwarder(vertx, selfClient, rule, this.storage, loggingResourceManager, monitoringHandler, userProfileUri);
+                forwarder = new Forwarder(vertx, selfClient, rule, this.storage, loggingResourceManager, monitoringHandler, userProfileUri, httpHeaderUtil);
             } else {
-                forwarder = new Forwarder(vertx, client, rule, this.storage, loggingResourceManager, monitoringHandler, userProfileUri);
+                forwarder = new Forwarder(vertx, client, rule, this.storage, loggingResourceManager, monitoringHandler, userProfileUri, httpHeaderUtil);
             }
 
             if (rule.getMethods() == null) {

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Router.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Router.java
@@ -44,7 +44,6 @@ public class Router implements Refreshable, LoggableResource, ConfigurationResou
     public static final String ROUTER_STATE_MAP = "router_state_map";
     public static final String ROUTER_BROKEN_KEY = "router_broken";
     public static final String REQUEST_HOPS_LIMIT_PROPERTY = "request.hops.limit";
-    private final HttpHeaderUtil httpHeaderUtil = new HttpHeaderUtil();
     private String rulesUri;
     private String userProfileUri;
     private String serverUri;
@@ -359,9 +358,9 @@ public class Router implements Refreshable, LoggableResource, ConfigurationResou
             } else if (rule.getStorage() != null) {
                 forwarder = new StorageForwarder(vertx.eventBus(), rule, loggingResourceManager, monitoringHandler);
             } else if (rule.getScheme().equals("local")) {
-                forwarder = new Forwarder(vertx, selfClient, rule, this.storage, loggingResourceManager, monitoringHandler, userProfileUri, httpHeaderUtil);
+                forwarder = new Forwarder(vertx, selfClient, rule, this.storage, loggingResourceManager, monitoringHandler, userProfileUri);
             } else {
-                forwarder = new Forwarder(vertx, client, rule, this.storage, loggingResourceManager, monitoringHandler, userProfileUri, httpHeaderUtil);
+                forwarder = new Forwarder(vertx, client, rule, this.storage, loggingResourceManager, monitoringHandler, userProfileUri);
             }
 
             if (rule.getMethods() == null) {


### PR DESCRIPTION
According to RFC 2616 section 14.10
(https://tools.ietf.org/html/rfc2616#section-14.10)

The Connection headers "MUST NOT be communicated by proxies over further
connections".

This was already implemented earlier in the request stream in gateleen.
But not for the response stream. This will implement it for this stream
now.