### PR TITLE
Bugfix react on ungraceful closed client connections

### DIFF
--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
@@ -262,6 +262,12 @@ public class Forwarder implements Handler<RoutingContext> {
                 }
             } else {
                 error(exception.getMessage(), req, targetUri);
+                if (req.response().ended() || req.response().headWritten()) {
+                    error("Response already written. Not sure about the state. Closing server connection for stability reason", req, targetUri);
+                    req.response().close();
+                    return;
+                }
+
                 req.response().setStatusCode(StatusCode.SERVICE_UNAVAILABLE.getStatusCode());
                 req.response().setStatusMessage(StatusCode.SERVICE_UNAVAILABLE.getStatusMessage());
                 try {


### PR DESCRIPTION
This solves #221.
Now, when upstream server closes its connection after it sended a http-Response, then we also close the connection from our own client.