### PR TITLE
Issue 234: Totally remove "x-expire-after" handling in HookHandler (for hooked resources)

### DIFF
--- a/gateleen-hook/README_hook.md
+++ b/gateleen-hook/README_hook.md
@@ -21,7 +21,7 @@ During the instantiation of the [HookHandler](src/main/java/org/swisspush/gatele
 |:----------------- | :------: | :--------------------------------------- | 
 | destination       | yes | A valid URL (absolute) where the requests should be redirected to. |
 | methods           | no  | An array of valid HTTP methods (PUT, GET, DELETE, ...) to define for which requests the redirection should be performed. As a default all requests will be redirected. |
-| expireAfter       | no  | This property indicates how long a resource should live. After the given time, the resource will be removed from the storage. This property will only be used, if the incoming request does not have a 'X-Expire-After' header. If the given header exists, this property will be ignored for the given request!  |
+| *expireAfter*     | no  | *DEPRECATED - Hooks don't manipulate or set the x-expire-after header any more. Use HeaderFunctions instead* |
 | staticHeaders     | no  | (*deprecated - use headers*) This property allows you to set static headers passed down to every request. The defined static headers will overwrite given ones! |
 | headers           | no  | array of request header manipulations: set, remove, complete (set-if-absent) and override (set-if-present)|
 | collection        | no  | This property specifies if the given URL is a resource or a collection. If this property is not set, the default is true (collection). |
@@ -131,7 +131,7 @@ GET http://myserver:7012/gateleen/example/
 |:----------------- | :------: | :--------------------------------------- | 
 | destination       | yes | A valid URL (relative) where the requests should be redirected to. |
 | methods           | no  | An array of valid HTTP methods (PUT, GET, DELETE, ...) to define for which requests the redirection should be performed. As a default all requests will be redirected. |
-| expireAfter       | no  | This property indicates how long a resource should live. After the given time, the resource will be removed from the storage. This property will only be used, if the incoming request does not have a 'X-Expire-After' header. If the given header exists, this property will be ignored for the given request!  |
+| *expireAfter*     | no  | *DEPRECATED - Hooks don't manipulate or set the x-expire-after header any more. Use HeaderFunctions instead* |
 | queueExpireAfter  | no  | A copied and forwarded request to a listener is always putted into a queue. To ensure to have an expiration time for each request within the given listener queue, you can set a default value (in seconds) with this property. This way you can prevent a queue overflow. The property will only be used for requests, which doesn’t have a _x-queue-expire-after_ header. |
 | staticHeaders     | no  | (*deprecated - use headers*) This property allows you to set static headers passed down to every request. The defined static headers will overwrite given ones! |
 | headers           | no  | array of request header manipulations: set, remove, complete (set-if-absent) and override (set-if-present)|

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -71,13 +71,11 @@ public class HookHandler implements LoggableResource {
     private static final String REMOVE_ROUTE_ADDRESS = "gateleen.hook-route-remove";
 
     private static final int DEFAULT_HOOK_STORAGE_EXPIRE_AFTER_TIME = 1 * 60 * 60; // 1h in seconds
-    private static final int DEFAULT_HOOK_LISTENERS_EXPIRE_AFTER_TIME = 30; // 30 seconds
 
     private static final int DEFAULT_CLEANUP_TIME = 15000; // 15 seconds
     public static final String REQUESTURL = "requesturl";
     public static final String EXPIRATION_TIME = "expirationTime";
     public static final String HOOK = "hook";
-    public static final String EXPIRE_AFTER = "expireAfter";
     public static final String QUEUE_EXPIRE_AFTER = "queueExpireAfter";
     public static final String STATIC_HEADERS = "staticHeaders";
     public static final String FULL_URL = "fullUrl";
@@ -715,10 +713,6 @@ public class HookHandler implements LoggableResource {
                 log.warn("problem applying header manipulator chain {} in listener {}", evalScope.getErrorMessage(), listener.getListenerId());
             }
 
-            if (ExpiryCheckHandler.getExpireAfter(queueHeaders) == null) {
-                ExpiryCheckHandler.setExpireAfter(queueHeaders, listener.getHook().getExpireAfter());
-            }
-
             if (ExpiryCheckHandler.getQueueExpireAfter(queueHeaders) == null && listener.getHook().getQueueExpireAfter() != -1) {
                 ExpiryCheckHandler.setQueueExpireAfter(queueHeaders, listener.getHook().getQueueExpireAfter());
             }
@@ -1215,12 +1209,6 @@ public class HookHandler implements LoggableResource {
             hook.setFilter(jsonHook.getString("filter"));
         }
 
-        if (jsonHook.getInteger(EXPIRE_AFTER) != null) {
-            hook.setExpireAfter(jsonHook.getInteger(EXPIRE_AFTER));
-        } else {
-            hook.setExpireAfter(DEFAULT_HOOK_LISTENERS_EXPIRE_AFTER_TIME);
-        }
-
         if (jsonHook.getInteger(QUEUE_EXPIRE_AFTER) != null ) {
             hook.setQueueExpireAfter(jsonHook.getInteger(QUEUE_EXPIRE_AFTER));
         }
@@ -1364,12 +1352,6 @@ public class HookHandler implements LoggableResource {
         HttpHook hook = new HttpHook(jsonHook.getString("destination"));
         if (jsonMethods != null) {
             hook.setMethods(jsonMethods.getList());
-        }
-
-        if (jsonHook.getInteger(EXPIRE_AFTER) != null) {
-            hook.setExpireAfter(jsonHook.getInteger(EXPIRE_AFTER));
-        } else {
-            hook.setExpireAfter(DEFAULT_HOOK_LISTENERS_EXPIRE_AFTER_TIME);
         }
 
         if (jsonHook.getInteger(QUEUE_EXPIRE_AFTER) != null ) {

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HttpHook.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HttpHook.java
@@ -19,7 +19,6 @@ import java.util.regex.Pattern;
 public class HttpHook {
     private String destination;
     private List<String> methods;
-    private int expireAfter;
     private LocalDateTime expirationTime;
     private boolean fullUrl = false;
     private QueueingStrategy queueingStrategy = new DefaultQueueingStrategy();
@@ -76,26 +75,6 @@ public class HttpHook {
      */
     public void setMethods(List<String> methods) {
         this.methods = methods;
-    }
-
-    /**
-     * Gets the expiry (x-expire-after header)
-     * for the requests send to the listener.
-     * 
-     * @return a value in seconds
-     */
-    public int getExpireAfter() {
-        return expireAfter;
-    }
-
-    /**
-     * Sets the expiry (x-expire-after header)
-     * for the requests send to the listener.
-     * 
-     * @param expireAfter - a value in seconds
-     */
-    public void setExpireAfter(int expireAfter) {
-        this.expireAfter = expireAfter;
     }
 
     /**

--- a/gateleen-hook/src/main/resources/gateleen_hooking_schema_hook
+++ b/gateleen-hook/src/main/resources/gateleen_hooking_schema_hook
@@ -38,6 +38,7 @@
             "type": "string"
         },
         "expireAfter": {
+            "description": "DEPRECATED - Hooks don't manipulate or set the x-expire-after header any more. Use HeaderFunctions instead",
             "type": "integer",
             "minimum": -1
         },

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/TestUtils.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/TestUtils.java
@@ -266,70 +266,60 @@ public class TestUtils {
 
     /**
      * Registers a listener.
-     *
-     * @param requestUrl
+     *  @param requestUrl
      * @param target
      * @param methods
-     * @param expireTime
      */
-    public static void registerListener(final String requestUrl, final String target, String[] methods, Integer expireTime) {
-        registerListener(requestUrl, target, methods, expireTime, null);
+    public static void registerListener(final String requestUrl, final String target, String[] methods) {
+        registerListener(requestUrl, target, methods, null);
     }
 
     /**
      * Registers a listener.
-     *
-     * @param requestUrl
+     *  @param requestUrl
      * @param target
      * @param methods
-     * @param expireTime
      * @param filter
      */
-    public static void registerListener(final String requestUrl, final String target, String[] methods, Integer expireTime, String filter) {
-        registerListener(requestUrl, target, methods, expireTime, filter, null);
+    public static void registerListener(final String requestUrl, final String target, String[] methods, String filter) {
+        registerListener(requestUrl, target, methods, filter, null);
     }
 
     /**
      * Registers a listener with a filter.
-     *
-     * @param requestUrl
+     *  @param requestUrl
      * @param target
      * @param methods
-     * @param expireTime
      * @param filter
      * @param queueExpireTime
      */
-    public static void registerListener(final String requestUrl, final String target, String[] methods, Integer expireTime, String filter, Integer queueExpireTime) {
-        registerListener(requestUrl, target, methods, expireTime, filter, queueExpireTime, null);
+    public static void registerListener(final String requestUrl, final String target, String[] methods, String filter, Integer queueExpireTime) {
+        registerListener(requestUrl, target, methods, filter, queueExpireTime, null);
     }
 
     /**
      * Registers a listener with a filter and static headers.
-     *
-     * @param requestUrl
+     *  @param requestUrl
      * @param target
      * @param methods
-     * @param expireTime
      * @param filter
      * @param queueExpireTime
      * @param staticHeaders
      */
-    public static void registerListener(final String requestUrl, final String target, String[] methods, Integer expireTime, String filter, Integer queueExpireTime, Map<String, String> staticHeaders) {
-        registerListener(requestUrl, target, methods, expireTime, filter, queueExpireTime, staticHeaders, null);
+    public static void registerListener(final String requestUrl, final String target, String[] methods, String filter, Integer queueExpireTime, Map<String, String> staticHeaders) {
+        registerListener(requestUrl, target, methods, filter, queueExpireTime, staticHeaders, null);
     }
 
     /**
      * Registers a listener with a filter, static headers and a event trigger.
-     *
-     * @param requestUrl
+     *  @param requestUrl
      * @param target
      * @param methods
-     * @param expireTime
      * @param filter
      * @param queueExpireTime
      * @param staticHeaders
      */
-    public static void registerListener(final String requestUrl, final String target, String[] methods, Integer expireTime, String filter, Integer queueExpireTime, Map<String, String> staticHeaders, HookTriggerType type) {
+    public static void registerListener(final String requestUrl, final String target, String[] methods, String filter, Integer queueExpireTime, Map<String, String> staticHeaders, HookTriggerType type) {
         String body = "{ \"destination\":\"" + target + "\"";
 
         if (methods != null) {
@@ -341,7 +331,6 @@ public class TestUtils {
             m = ",\"methods\": [" + m + "]";
             body += m;
         }
-        body += expireTime != null ? ", \""+ HookHandler.EXPIRE_AFTER + "\" : " + expireTime : "";
         body += queueExpireTime != null ? ", \""+ HookHandler.QUEUE_EXPIRE_AFTER + "\" : " + queueExpireTime : "";
         body += filter != null ? ", \"filter\" : \"" + filter + "\"" : "";
         body += type != null ? ", \"type\" : \"" + type.text() + "\"" : "";

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/TestUtils.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/TestUtils.java
@@ -266,7 +266,8 @@ public class TestUtils {
 
     /**
      * Registers a listener.
-     *  @param requestUrl
+     *
+     * @param requestUrl
      * @param target
      * @param methods
      */
@@ -276,7 +277,8 @@ public class TestUtils {
 
     /**
      * Registers a listener.
-     *  @param requestUrl
+     *
+     * @param requestUrl
      * @param target
      * @param methods
      * @param filter
@@ -287,7 +289,8 @@ public class TestUtils {
 
     /**
      * Registers a listener with a filter.
-     *  @param requestUrl
+     *
+     * @param requestUrl
      * @param target
      * @param methods
      * @param filter
@@ -299,7 +302,8 @@ public class TestUtils {
 
     /**
      * Registers a listener with a filter and static headers.
-     *  @param requestUrl
+     *
+     * @param requestUrl
      * @param target
      * @param methods
      * @param filter
@@ -312,7 +316,8 @@ public class TestUtils {
 
     /**
      * Registers a listener with a filter, static headers and a event trigger.
-     *  @param requestUrl
+     *
+     * @param requestUrl
      * @param target
      * @param methods
      * @param filter

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
@@ -118,7 +118,7 @@ public class ListenerTest extends AbstractTest {
         delete(targetUrl);
 
         // register a listener
-        TestUtils.registerListener(registerUrl, target, methods, 4);
+        TestUtils.registerListener(registerUrl, target, methods);
 
         // send request
         checkPUTStatusCode(requestUrl, body, 200);
@@ -194,7 +194,7 @@ public class ListenerTest extends AbstractTest {
         /*
          * Sending request, one listener hooked
          */
-        TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1, 4);
+        TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1);
 
         checkPUTStatusCode(requestUrl, body, 200);
         checkGETStatusCodeWithAwait(requestUrl, 200);
@@ -209,8 +209,8 @@ public class ListenerTest extends AbstractTest {
         /*
          * Sending request, both listener hooked
          */
-        TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1, 4);
-        TestUtils.registerListener(registerUrlListener2, targetListener2, methodsListener2, 4);
+        TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1);
+        TestUtils.registerListener(registerUrlListener2, targetListener2, methodsListener2);
 
         checkPUTStatusCode(requestUrl, body, 200);
         checkGETStatusCodeWithAwait(requestUrl, 200);
@@ -296,7 +296,7 @@ public class ListenerTest extends AbstractTest {
         /*
          * Sending request, master listener hooked
          */
-        TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1, 30);
+        TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1);
 
         checkPUTStatusCode(requestUrlMaster, body, 200);
         checkGETStatusCodeWithAwait(requestUrlMaster, 200);
@@ -319,8 +319,8 @@ public class ListenerTest extends AbstractTest {
         /*
          * Sending request, both listener hooked
          */
-        TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1, 30);
-        TestUtils.registerListener(registerUrlListener2, targetListener2, methodsListener2, 30);
+        TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1);
+        TestUtils.registerListener(registerUrlListener2, targetListener2, methodsListener2);
 
         checkPUTStatusCode(requestUrlMaster, body, 200);
         checkGETStatusCodeWithAwait(requestUrlMaster, 200);
@@ -346,7 +346,7 @@ public class ListenerTest extends AbstractTest {
         /*
          * Sending request, slave listener hooked
          */
-        TestUtils.registerListener(registerUrlListener2, targetListener2, methodsListener2, 30);
+        TestUtils.registerListener(registerUrlListener2, targetListener2, methodsListener2);
 
         checkPUTStatusCode(requestUrlMaster, body, 200);
         checkGETStatusCodeWithAwait(requestUrlMaster, 200);
@@ -443,7 +443,7 @@ public class ListenerTest extends AbstractTest {
         String target2 = target + "/456/notfiltered/v1/body";
 
         // register listener
-        TestUtils.registerListener(registerUrlListener, target, null, null, pattern);
+        TestUtils.registerListener(registerUrlListener, target, null, pattern);
 
         // Put1
         checkPUTStatusCode(put1, body, 200);
@@ -486,7 +486,7 @@ public class ListenerTest extends AbstractTest {
         /*
          * Sending request, both listener hooked
          */
-        TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1, 4, null, null, null, HookTriggerType.AFTER);
+        TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1, null, null, null, HookTriggerType.AFTER);
 
         checkPUTStatusCode(requestUrl, body, 200);
         checkGETStatusCodeWithAwait(requestUrl, 200);
@@ -536,8 +536,8 @@ public class ListenerTest extends AbstractTest {
         /*
          * Sending request, both listener hooked
          */
-        TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1, 4, null, null, null, HookTriggerType.AFTER);
-        TestUtils.registerListener(registerUrlListener2, targetListener2, methodsListener2, 4, null, null, null, HookTriggerType.BEFORE);
+        TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1, null, null, null, HookTriggerType.AFTER);
+        TestUtils.registerListener(registerUrlListener2, targetListener2, methodsListener2, null, null, null, HookTriggerType.BEFORE);
 
         checkPUTStatusCode(requestUrl, body, 200);
         checkGETStatusCodeWithAwait(requestUrl, 200);
@@ -616,7 +616,7 @@ public class ListenerTest extends AbstractTest {
         // ----
 
         // register Listener
-        TestUtils.registerListener(requestUrl, targetUrl, null, 10, null, 5);
+        TestUtils.registerListener(requestUrl, targetUrl, null, null, 5);
 
         // lock queue
         String lockRequestUrl = "queuing/locks/" + queueName;
@@ -684,7 +684,7 @@ public class ListenerTest extends AbstractTest {
         delete(targetUrl);
 
         // register a listener
-        TestUtils.registerListener(registerUrl, target, methods, null, null, null, staticHeaders);
+        TestUtils.registerListener(registerUrl, target, methods, null, null, staticHeaders);
 
         // prepare WireMock (stateful)
         WireMock.stubFor(WireMock.put(WireMock.urlEqualTo(targetUrlPart)).inScenario(scenario)


### PR DESCRIPTION
This prevents accidential addition of an implicit "x-expire-after: 30" (30 Seconds) and also prevents overwrite of a "x-expire-after: -1".

Solves #234