### PR TITLE
[#238] Enable route hooks to set a connectionPoolSize

### DIFF
--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -1393,6 +1393,9 @@ public class HookHandler implements LoggableResource {
         hook.setFullUrl(storageObject.getBoolean(FULL_URL, false));
         hook.setQueueingStrategy(QueueingStrategyFactory.buildQueueStrategy(storageObject));
 
+        // Configure connection pool size
+        hook.setConnectionPoolSize(jsonHook.getInteger(HttpHook.CONNECTION_POOL_SIZE_PROPERTY_NAME));
+
         routeRepository.addRoute(routedUrl, createRoute(routedUrl, hook));
         monitoringHandler.updateRoutesCount(routeRepository.getRoutes().size());
     }

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HttpHook.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HttpHook.java
@@ -5,6 +5,7 @@ import org.swisspush.gateleen.core.http.HeaderFunction;
 import org.swisspush.gateleen.core.http.HeaderFunctions;
 import org.swisspush.gateleen.hook.queueingstrategy.DefaultQueueingStrategy;
 import org.swisspush.gateleen.hook.queueingstrategy.QueueingStrategy;
+import org.swisspush.gateleen.routing.Rule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,8 +18,8 @@ import java.util.regex.Pattern;
  * @author https://github.com/ljucam [Mario Ljuca]
  */
 public class HttpHook {
-    public static final String CONNECTION_POOL_SIZE_PROPERTY_NAME = "connectionPoolSize";
-    public static final int CONNECTION_POOL_SIZE_DEFAULT_VALUE = 50;
+    public static final String CONNECTION_POOL_SIZE_PROPERTY_NAME = Rule.CONNECTION_POOL_SIZE_PROPERTY_NAME;
+    public static final int CONNECTION_POOL_SIZE_DEFAULT_VALUE = Rule.CONNECTION_POOL_SIZE_DEFAULT_VALUE;
     private String destination;
     private List<String> methods;
     private LocalDateTime expirationTime;
@@ -242,7 +243,9 @@ public class HttpHook {
     }
 
     /**
-     * @return Max count of connections made to configured destination.
+     * @return Max count of connections made to configured destination. This may
+     *      returning null in case there's no value specified. Callers may catch
+     *      that by fall back to a default.
      */
     public Integer getConnectionPoolSize() {
         return connectionPoolSize;

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HttpHook.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HttpHook.java
@@ -17,6 +17,8 @@ import java.util.regex.Pattern;
  * @author https://github.com/ljucam [Mario Ljuca]
  */
 public class HttpHook {
+    public static final String CONNECTION_POOL_SIZE_PROPERTY_NAME = "connectionPoolSize";
+    public static final int CONNECTION_POOL_SIZE_DEFAULT_VALUE = 50;
     private String destination;
     private List<String> methods;
     private LocalDateTime expirationTime;
@@ -28,6 +30,7 @@ public class HttpHook {
     private HookTriggerType hookTriggerType;
     private boolean listable = false;
     private boolean collection = true;
+    private Integer connectionPoolSize = null;
 
     /**
      * Creates a new hook.
@@ -236,5 +239,22 @@ public class HttpHook {
      */
     public void setCollection(boolean collection) {
         this.collection = collection;
+    }
+
+    /**
+     * @return Max count of connections made to configured destination.
+     */
+    public Integer getConnectionPoolSize() {
+        return connectionPoolSize;
+    }
+
+    /**
+     * See {@link #getConnectionPoolSize()}.
+     */
+    public void setConnectionPoolSize(Integer connectionPoolSize) {
+        if (connectionPoolSize != null && connectionPoolSize < 1){
+            throw new IllegalArgumentException("Values below 1 not valid.");
+        }
+        this.connectionPoolSize = connectionPoolSize;
     }
 }

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
@@ -28,7 +28,6 @@ public class Route {
     /** How long to let the http clients live before closing them after a update on the forwarder */
     private static final int GRACE_PERIOD = 30000;
     private static final int CLIENT_DEFAULT_TIMEOUT_SEC = 30;
-    private static final int CLIENT_DEFAULT_POOL_SIZE = 5000;
     private static final boolean CLIENT_DEFAULT_KEEP_ALIVE = true;
     private static final boolean CLIENT_DEFAULT_EXPAND_ON_BACKEND = false;
     private static final boolean CLIENT_DEFAULT_EXPAND_IN_STORAGE = false;
@@ -97,12 +96,22 @@ public class Route {
         prepareUrl(rule, httpHook);
 
         rule.setTimeout(1000 * CLIENT_DEFAULT_TIMEOUT_SEC);
-        rule.setPoolSize(CLIENT_DEFAULT_POOL_SIZE);
         rule.setKeepAlive(CLIENT_DEFAULT_KEEP_ALIVE);
         rule.setExpandOnBackend(CLIENT_DEFAULT_EXPAND_ON_BACKEND);
         rule.setStorageExpand(CLIENT_DEFAULT_EXPAND_IN_STORAGE);
         rule.setLogExpiry(CLIENT_DEFAULT_LOG_EXPIRY);
         rule.setHeaderFunction(httpHook.getHeaderFunction());
+
+        { // Evaluate connection pool size
+            Integer connectionPoolSize = httpHook.getConnectionPoolSize();
+            if (connectionPoolSize == null) {
+                LOG.trace("No connectionPoolSize specified for route '{}' using default of {}.", rule.getRuleIdentifier(), HttpHook.CONNECTION_POOL_SIZE_DEFAULT_VALUE);
+                rule.setPoolSize(HttpHook.CONNECTION_POOL_SIZE_DEFAULT_VALUE);
+            } else {
+                LOG.trace("Using connectionPoolSize {} for route '{}'.", connectionPoolSize, rule.getRuleIdentifier());
+                rule.setPoolSize(connectionPoolSize);
+            }
+        }
 
         if (!httpHook.getMethods().isEmpty()) {
             rule.setMethods(httpHook.getMethods().toArray(new String[httpHook.getMethods().size()]));
@@ -157,22 +166,7 @@ public class Route {
         }
         // url request
         else {
-            Integer connectionPoolSize = httpHook.getConnectionPoolSize();
-            if (connectionPoolSize == null) {
-                connectionPoolSize = HttpHook.CONNECTION_POOL_SIZE_DEFAULT_VALUE;
-                LOG.debug("No connectionPoolSize specified for route '{}' using default of {}.", rule.getRuleIdentifier(), connectionPoolSize);
-            } else {
-                LOG.debug("Using connectionPoolSize of {} for route '{}'.", connectionPoolSize, rule.getRuleIdentifier());
-            }
-            HttpClientOptions options = new HttpClientOptions()
-                    .setDefaultHost(rule.getHost())
-                    .setDefaultPort(rule.getPort())
-                    .setMaxPoolSize(connectionPoolSize)
-                    .setKeepAlive(true)
-                    .setPipelining(false);
-            if (rule.getScheme().equals("https")) {
-                options.setSsl(true).setVerifyHost(false).setTrustAll(true);
-            }
+            HttpClientOptions options = rule.buildHttpClientOptions();
             client = vertx.createHttpClient(options);
         }
     }

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
@@ -157,7 +157,19 @@ public class Route {
         }
         // url request
         else {
-            HttpClientOptions options = new HttpClientOptions().setDefaultHost(rule.getHost()).setDefaultPort(rule.getPort()).setMaxPoolSize(5000).setKeepAlive(true).setPipelining(false);
+            Integer connectionPoolSize = httpHook.getConnectionPoolSize();
+            if (connectionPoolSize == null) {
+                connectionPoolSize = HttpHook.CONNECTION_POOL_SIZE_DEFAULT_VALUE;
+                LOG.debug("No connectionPoolSize specified for route '{}' using default of {}.", rule.getRuleIdentifier(), connectionPoolSize);
+            } else {
+                LOG.debug("Using connectionPoolSize of {} for route '{}'.", connectionPoolSize, rule.getRuleIdentifier());
+            }
+            HttpClientOptions options = new HttpClientOptions()
+                    .setDefaultHost(rule.getHost())
+                    .setDefaultPort(rule.getPort())
+                    .setMaxPoolSize(connectionPoolSize)
+                    .setKeepAlive(true)
+                    .setPipelining(false);
             if (rule.getScheme().equals("https")) {
                 options.setSsl(true).setVerifyHost(false).setTrustAll(true);
             }

--- a/gateleen-hook/src/main/resources/gateleen_hooking_schema_hook
+++ b/gateleen-hook/src/main/resources/gateleen_hooking_schema_hook
@@ -73,6 +73,11 @@
             },
             "additionalProperties": false
         },
+        "connectionPoolSize": {
+            "description": "The maximum number of concurrent connections to the destination.",
+            "type": "integer",
+            "default": 50
+        },
         "collection": {
             "description": "only used for route hook",
             "type": "boolean"

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Router.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Router.java
@@ -329,24 +329,10 @@ public class Router implements Refreshable, LoggableResource, ConfigurationResou
         return sharedData;
     }
 
-    private HttpClientOptions buildHttpClientOptions(Rule rule) {
-        HttpClientOptions options = new HttpClientOptions()
-                .setDefaultHost(rule.getHost())
-                .setDefaultPort(rule.getPort())
-                .setMaxPoolSize(rule.getPoolSize())
-                .setConnectTimeout(rule.getTimeout())
-                .setKeepAlive(rule.isKeepAlive())
-                .setPipelining(false);
-
-        if (rule.getScheme().equals("https")) {
-            options.setSsl(true).setVerifyHost(false).setTrustAll(true);
-        }
-        return options;
-    }
-
     private void createForwarders(List<Rule> rules, io.vertx.ext.web.Router newRouter, Set<HttpClient> newClients) {
         for (Rule rule : rules) {
-            HttpClient client = vertx.createHttpClient(buildHttpClientOptions(rule));
+            // TODO: Could we move that into the only if branch where it actually is used?
+            HttpClient client = vertx.createHttpClient( rule.buildHttpClientOptions() );
             /*
              * in case of a null - routing
              * the host field of the rule
@@ -369,6 +355,7 @@ public class Router implements Refreshable, LoggableResource, ConfigurationResou
             } else {
                 installMethodForwarder(newRouter, rule, forwarder);
             }
+            // TODO: Could we do that only in the if branch where it actually is used?
             newClients.add(client);
         }
     }

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Rule.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Rule.java
@@ -1,5 +1,6 @@
 package org.swisspush.gateleen.routing;
 
+import io.vertx.core.http.HttpClientOptions;
 import org.swisspush.gateleen.core.http.HeaderFunction;
 import org.swisspush.gateleen.core.http.HeaderFunctions;
 
@@ -9,6 +10,8 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 public class Rule {
+    public static final String CONNECTION_POOL_SIZE_PROPERTY_NAME = "connectionPoolSize";
+    public static final int CONNECTION_POOL_SIZE_DEFAULT_VALUE = 50;
     private String scheme;
     private String host;
     private String metricName;
@@ -182,4 +185,20 @@ public class Rule {
     public void setStorage(String storage) {
         this.storage = storage;
     }
+
+    public HttpClientOptions buildHttpClientOptions() {
+        final HttpClientOptions options = new HttpClientOptions()
+                .setDefaultHost   (getHost    ())
+                .setDefaultPort   (getPort    ())
+                .setMaxPoolSize   (getPoolSize())
+                .setConnectTimeout(getTimeout ())
+                .setKeepAlive     (isKeepAlive())
+                .setPipelining    (false        )
+        ;
+        if ("https".equals(getScheme())) {
+            options.setSsl(true).setVerifyHost(false).setTrustAll(true);
+        }
+        return options;
+    }
+
 }

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RuleFactory.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RuleFactory.java
@@ -13,7 +13,6 @@ import org.swisspush.gateleen.validation.ValidationException;
 import org.swisspush.gateleen.validation.Validator;
 
 import java.util.*;
-import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -80,7 +79,7 @@ public class RuleFactory {
 
             int defaultTimeoutSec = 30;
             ruleObj.setTimeout(1000 * rule.getInteger("timeout", defaultTimeoutSec));
-            ruleObj.setPoolSize(rule.getInteger("connectionPoolSize", 50));
+            ruleObj.setPoolSize(rule.getInteger(Rule.CONNECTION_POOL_SIZE_PROPERTY_NAME, Rule.CONNECTION_POOL_SIZE_DEFAULT_VALUE));
             ruleObj.setKeepAlive(rule.getBoolean("keepAlive", true));
             ruleObj.setExpandOnBackend(rule.getBoolean("expandOnBackend", false));
             ruleObj.setStorageExpand(rule.getBoolean("storageExpand", false));


### PR DESCRIPTION
- Defined new hook property 'connectionPoolSize'
- Using default connectionPoolSize of 50 (was 5000 before)