### PR TITLE
240: Add error handling for crashing delta handler

### DIFF
--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/LocalHttpServerResponse.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/LocalHttpServerResponse.java
@@ -1,11 +1,16 @@
 package org.swisspush.gateleen.core.http;
 
 import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.http.*;
-import org.swisspush.gateleen.core.util.StatusCode;
-import io.vertx.core.*;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
 import io.vertx.core.net.NetSocket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.swisspush.gateleen.core.util.StatusCode;
 
 import java.util.List;
 
@@ -16,6 +21,7 @@ import java.util.List;
  */
 public class LocalHttpServerResponse extends BufferBridge implements HttpServerResponse {
 
+    private static final Logger logger = LoggerFactory.getLogger(LocalHttpServerResponse.class);
     private int statusCode;
     private String statusMessage;
     private static final String EMPTY = "";
@@ -130,6 +136,10 @@ public class LocalHttpServerResponse extends BufferBridge implements HttpServerR
 
     public LocalHttpServerResponse(Vertx vertx, Handler<HttpClientResponse> responseHandler) {
         super(vertx);
+        // Attach most simple possible exception handler to base.
+        setExceptionHandler(thr -> {
+            logger.error("Processing of response failed.", thr);
+        });
         this.responseHandler = responseHandler;
     }
 

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/ExpansionDeltaUtil.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/ExpansionDeltaUtil.java
@@ -1,20 +1,23 @@
 package org.swisspush.gateleen.core.util;
 
-import org.swisspush.gateleen.core.http.RequestLoggerFactory;
 import com.google.common.base.Joiner;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.swisspush.gateleen.core.http.RequestLoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * <p>
@@ -277,7 +280,23 @@ public final class ExpansionDeltaUtil {
             throw new ResourceCollectionException("Request did not return data. Invalid usage of params " + params + " ?", StatusCode.BAD_REQUEST);
         }
 
-        JsonObject obj = new JsonObject(data.toString("UTF-8"));
+        // Parse payload
+        final String dataAsString = data.toString(UTF_8);
+        final JsonObject obj;
+        try {
+            obj = new JsonObject(dataAsString);
+        } catch (DecodeException e) {
+            final int MAX_CHARS_TO_PRINT = 4096;
+            final String msgHead = "Failed to decode data as JSON.";
+            final String msgTail = "First " + MAX_CHARS_TO_PRINT + " characters were:\n" +
+                    // Append first n characters from malformed data
+                    dataAsString.substring(0, Math.min(MAX_CHARS_TO_PRINT, dataAsString.length())) + "\n";
+            // Log as INFO only because this situation is not our fault and we can continue
+            // our service with no problems.
+            log.info(msgHead, e);
+            throw new ResourceCollectionException(msgHead + "\n\n" + msgTail, StatusCode.BAD_GATEWAY, e);
+        }
+
         JsonArray collectionEntries = obj.getJsonArray(collectionName);
         if (collectionEntries == null) {
             throw new ResourceCollectionException("Collection with name '" + collectionName + "' not found in result of request " + targetPath, StatusCode.BAD_REQUEST);

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/ResourceCollectionException.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/ResourceCollectionException.java
@@ -20,6 +20,11 @@ public class ResourceCollectionException extends Exception {
         this.statusCode = statusCode;
     }
 
+    public ResourceCollectionException(String message, StatusCode statusCode, Throwable cause) {
+        super(message != null ? message : statusCode.getStatusMessage(), cause);
+        this.statusCode = statusCode;
+    }
+
     public StatusCode getStatusCode() {
         return statusCode;
     }

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/StatusCode.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/StatusCode.java
@@ -15,6 +15,7 @@ public enum StatusCode {
     METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
     CONFLICT(409, "Conflict"),
     INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
+    BAD_GATEWAY(502, "Bad Gateway"),
     SERVICE_UNAVAILABLE(503, "Service Unavailable"),
     TIMEOUT(504,"Gateway Timeout"),
     INSUFFICIENT_STORAGE(507, "Insufficient Storage");


### PR DESCRIPTION
- Attach a general error handler in LocalHttpServerResponse to log such
  issues
- Handle undocumented DecodeException by throwing a corresponding
  ResourceCollectionException