### PR TITLE
Use EventBus.consumer instead of EventBus.localConsumer due to much better performance in clustered environment.

### DIFF
--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueueProcessor.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueueProcessor.java
@@ -62,7 +62,7 @@ public class QueueProcessor {
     public void startQueueProcessing(){
         if(this.consumer == null || !this.consumer.isRegistered()) {
             log.info("about to register consumer to start queue processing");
-            this.consumer = vertx.eventBus().localConsumer(getQueueProcessorAddress(), (Handler<Message<JsonObject>>) message -> {
+            this.consumer = vertx.eventBus().consumer(getQueueProcessorAddress(), (Handler<Message<JsonObject>>) message -> {
                 HttpRequest queuedRequestTry = null;
                 JsonObject jsonRequest = new JsonObject(message.body().getString("payload"));
                 try {


### PR DESCRIPTION
Use EventBus.consumer instead of EventBus.localConsumer due to much better performance in clustered environment.
See also https://github.com/eclipse/vert.x/issues/2617 and https://gist.github.com/oli-h/e44c9e42033bd10945dc6c6afa460fcb

Solves #244