### PR TITLE
[#249] Enable QueueProcessor to handle other HTTP methods

### DIFF
--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/HttpRequest.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/HttpRequest.java
@@ -50,6 +50,11 @@ public class HttpRequest {
 
     /**
      * @param object object
+     * @throws IllegalArgumentException
+     *      When passed in JSON is not in expected format.
+     * @throws ClassCastException
+     *      IMO, this should be a {@link IllegalArgumentException}. Because this
+     *      happens when impl tries to cast something we got from passed in JSON.
      */
     public HttpRequest(JsonObject object) {
         this.method = HttpMethod.valueOf(object.getString("method"));
@@ -58,13 +63,22 @@ public class HttpRequest {
             throw new IllegalArgumentException("Request fields 'uri' and 'method' must be set");
         }
         switch (method) {
+        // We accept those methods:
         case GET:
+        case HEAD:
         case PUT:
         case POST:
         case DELETE:
+        case OPTIONS:
+        case PATCH:
             break;
         default:
-            throw new IllegalArgumentException("Request method must be one of GET, PUT, POST or DELETE");
+            // This (default branch) gets reached when:
+            // 1. Someone is using a (for us) unknown http method (eg someone added a new
+            //    one in the enum since this here was written).
+            // 2. We explicitly forbid CONNECT, TRACE and OTHER.
+            //    See "https://github.com/swisspush/gateleen/issues/249".
+            throw new IllegalArgumentException("Request method must be one of GET, HEAD, PUT, POST, DELETE, OPTIONS or PATCH");
         }
         JsonArray headersArray = object.getJsonArray("headers");
         if (headersArray != null) {

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/HttpRequest.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/HttpRequest.java
@@ -1,10 +1,10 @@
 package org.swisspush.gateleen.core.http;
 
-import org.swisspush.gateleen.core.json.JsonMultiMap;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.swisspush.gateleen.core.json.JsonMultiMap;
 
 import java.util.Arrays;
 
@@ -63,14 +63,14 @@ public class HttpRequest {
             throw new IllegalArgumentException("Request fields 'uri' and 'method' must be set");
         }
         switch (method) {
-        // We accept those methods:
+            // We accept those methods:
         case GET:
-        case HEAD:
+            case HEAD:
         case PUT:
         case POST:
         case DELETE:
-        case OPTIONS:
-        case PATCH:
+            case OPTIONS:
+            case PATCH:
             break;
         default:
             // This (default branch) gets reached when:

--- a/gateleen-hook/README_hook.md
+++ b/gateleen-hook/README_hook.md
@@ -130,7 +130,7 @@ GET http://myserver:7012/gateleen/example/
 | Property          | Required | Description                              | 
 |:----------------- | :------: | :--------------------------------------- | 
 | destination       | yes | A valid URL (relative) where the requests should be redirected to. |
-| methods           | no  | An array of valid HTTP methods (PUT, GET, DELETE, ...) to define for which requests the redirection should be performed. As a default all requests will be redirected. |
+| methods           | no  | An array of HTTP methods (namely: GET, HEAD, PUT, POST, DELETE, OPTIONS and PATCH) to define for which requests the redirection should be performed. As a default all requests will be redirected. Requests with not whitelisted methods will not be redirected and get dropped instead. |
 | *expireAfter*     | no  | *DEPRECATED - Hooks don't manipulate or set the x-expire-after header any more. Use HeaderFunctions instead* |
 | queueExpireAfter  | no  | A copied and forwarded request to a listener is always putted into a queue. To ensure to have an expiration time for each request within the given listener queue, you can set a default value (in seconds) with this property. This way you can prevent a queue overflow. The property will only be used for requests, which doesn’t have a _x-queue-expire-after_ header. |
 | staticHeaders     | no  | (*deprecated - use headers*) This property allows you to set static headers passed down to every request. The defined static headers will overwrite given ones! |

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -1005,7 +1005,7 @@ public class HookHandler implements LoggableResource {
         log.debug("handleListenerRegistration > " + request.uri());
 
         request.bodyHandler(hookData -> {
-            if(isListenerJsonInvalid(request, hookData)) {
+            if (isListenerJsonInvalid(request, hookData)) {
                 return;
             }
 
@@ -1063,7 +1063,7 @@ public class HookHandler implements LoggableResource {
     }
 
     private boolean isListenerJsonInvalid(HttpServerRequest request, Buffer hookData) {
-        if( isHookJsonInvalid(request, hookData)){
+        if (isHookJsonInvalid(request, hookData)) {
             // No further checks required. hook definitively is invalid.
             return true;
         }
@@ -1078,12 +1078,12 @@ public class HookHandler implements LoggableResource {
             return true;
         }
         final JsonArray methods = hook.getJsonArray("methods");
-        if( methods != null ){
+        if (methods != null) {
             for (Object method : methods) {
-                if( !QueueProcessor.httpMethodIsQueueable( HttpMethod.valueOf((String)method) ) ){
-                    final String msg = "Listener registration request tries to hook for forbidden '"+method+"' method.";
-                    log.error( msg );
-                    badRequest(request, "Bad Request", msg+"\n" );
+                if (!QueueProcessor.httpMethodIsQueueable(HttpMethod.valueOf((String) method))) {
+                    final String msg = "Listener registration request tries to hook for not allowed '" + method + "' method.";
+                    log.error(msg);
+                    badRequest(request, "Bad Request", msg + "\n");
                     return true;
                 }
             }

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -33,6 +33,7 @@ import org.swisspush.gateleen.logging.LoggingResourceManager;
 import org.swisspush.gateleen.monitoring.MonitoringHandler;
 import org.swisspush.gateleen.queue.expiry.ExpiryCheckHandler;
 import org.swisspush.gateleen.queue.queuing.QueueClient;
+import org.swisspush.gateleen.queue.queuing.QueueProcessor;
 import org.swisspush.gateleen.queue.queuing.RequestQueue;
 import org.swisspush.gateleen.routing.Rule;
 
@@ -1004,7 +1005,7 @@ public class HookHandler implements LoggableResource {
         log.debug("handleListenerRegistration > " + request.uri());
 
         request.bodyHandler(hookData -> {
-            if(isHookJsonInvalid(request, hookData)) {
+            if(isListenerJsonInvalid(request, hookData)) {
                 return;
             }
 
@@ -1059,6 +1060,35 @@ public class HookHandler implements LoggableResource {
                 request.response().end();
             });
         });
+    }
+
+    private boolean isListenerJsonInvalid(HttpServerRequest request, Buffer hookData) {
+        if( isHookJsonInvalid(request, hookData)){
+            // No further checks required. hook definitively is invalid.
+            return true;
+        }
+
+        final JsonObject hook;
+        try {
+            // Badly we need to parse that JSON one more time.
+            hook = new JsonObject(hookData);
+        } catch (DecodeException e) {
+            log.error("Cannot decode JSON", e);
+            badRequest(request, "Cannot decode JSON", e.getMessage());
+            return true;
+        }
+        final JsonArray methods = hook.getJsonArray("methods");
+        if( methods != null ){
+            for (Object method : methods) {
+                if( !QueueProcessor.httpMethodIsQueueable( HttpMethod.valueOf((String)method) ) ){
+                    final String msg = "Listener registration request tries to hook for forbidden '"+method+"' method.";
+                    log.error( msg );
+                    badRequest(request, "Bad Request", msg+"\n" );
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     public boolean isHookJsonInvalid(HttpServerRequest request, Buffer hookData) {

--- a/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
+++ b/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
@@ -426,8 +426,8 @@ public class HookHandlerTest {
     public void listenerRegistration_acceptOnlyWhitelistedHttpMethods(TestContext testContext) {
 
         // Mock a request using all allowed request methods.
-        final int[] statusCodePtr = new int[]{ 0 };
-        final String[] statusMessagePtr = new String[]{ null };
+        final int[] statusCodePtr = new int[]{0};
+        final String[] statusMessagePtr = new String[]{null};
         final HttpServerRequest request;
         {
             final Buffer requestBody = toBuffer(new JsonObject("{" +
@@ -441,10 +441,10 @@ public class HookHandlerTest {
         }
 
         // Trigger
-        hookHandler.handle( request );
+        hookHandler.handle(request);
 
         { // Assert request got accepted.
-            testContext.assertEquals( 200 , statusCodePtr[0] );
+            testContext.assertEquals(200, statusCodePtr[0]);
         }
     }
 
@@ -452,24 +452,34 @@ public class HookHandlerTest {
     public void listenerRegistration_rejectNotWhitelistedHttpMethods(TestContext testContext) {
         final List<String> badMethods = Collections.unmodifiableList(new ArrayList<String>() {{
             // Some valid HTTP methods gateleen not accepts.
-            add("CONNECT"); add("TRACE");
+            add("CONNECT");
+            add("TRACE");
             // Some methods available in postman gateleen doesn't care about.
-            add("COPY"); add("LINK"); add("UNLINK"); add("PURGE"); add("LOCK");
-            add("UNLOCK"); add("PROPFIND"); add("VIEW");
+            add("COPY");
+            add("LINK");
+            add("UNLINK");
+            add("PURGE");
+            add("LOCK");
+            add("UNLOCK");
+            add("PROPFIND");
+            add("VIEW");
             // Some random, hopefully invalid methods.
-            add("FOO"); add("BAR"); add("ASDF"); add("ASSRGHAWERTH");
+            add("FOO");
+            add("BAR");
+            add("ASDF");
+            add("ASSRGHAWERTH");
         }});
 
         // Test every method.
         for (String method : badMethods) {
 
             // Mock a request using current method.
-            final int[] statusCodePtr = new int[]{ 0 };
-            final String[] statusMessagePtr = new String[]{ null };
+            final int[] statusCodePtr = new int[]{0};
+            final String[] statusMessagePtr = new String[]{null};
             final HttpServerRequest request;
             {
                 final Buffer requestBody = toBuffer(new JsonObject("{" +
-                        "    \"methods\": [ \""+ method +"\" ]," +
+                        "    \"methods\": [ \"" + method + "\" ]," +
                         "    \"destination\": \"/an/example/destination/\"" +
                         "}"
                 ));
@@ -479,13 +489,11 @@ public class HookHandlerTest {
             }
 
             // Trigger
-            hookHandler.handle( request );
+            hookHandler.handle(request);
 
             { // Assert request got rejected.
-                testContext.assertTrue( statusCodePtr[0] >= 400 );
-                testContext.assertTrue( statusCodePtr[0] <= 499 );
+                testContext.assertEquals(400, statusCodePtr[0]);
             }
-
         }
     }
 
@@ -515,8 +523,8 @@ public class HookHandlerTest {
         assertEquals(400, response.getStatusCode());
     }
 
-    private HttpServerRequest createSimpleRequest(final HttpMethod method , final String uri , final Buffer requestBody , final int[] statusCodePtr , final String[] statusMessagePtr ) {
-        return createSimpleRequest( method , uri  ,new CaseInsensitiveHeaders(), requestBody , statusCodePtr , statusMessagePtr );
+    private HttpServerRequest createSimpleRequest(final HttpMethod method, final String uri, final Buffer requestBody, final int[] statusCodePtr, final String[] statusMessagePtr) {
+        return createSimpleRequest(method, uri, new CaseInsensitiveHeaders(), requestBody, statusCodePtr, statusMessagePtr);
     }
 
     /**
@@ -574,7 +582,7 @@ public class HookHandlerTest {
 
     private Buffer toBuffer(JsonObject jsonObject) {
         final Buffer buffer = new BufferImpl();
-        buffer.setBytes(0, jsonObject.toString().getBytes() );
+        buffer.setBytes(0, jsonObject.toString().getBytes());
         return buffer;
     }
 

--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueueClient.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueueClient.java
@@ -208,9 +208,9 @@ public class QueueClient implements RequestQueue {
      * @param doneHandler   a handler which is called as soon as the request is written into the queue.
      */
     private void enqueue(final HttpServerRequest request, HttpRequest queuedRequest, final String queue, final Handler<Void> doneHandler) {
-        if( !QueueProcessor.httpMethodIsQueueable(queuedRequest.getMethod()) ){
-            log.warn( "Ignore enqueue of unsupported HTTP method in '{} {}'.", queuedRequest.getMethod() , queuedRequest.getUri());
-            if( doneHandler != null ) doneHandler.handle(null);
+        if (!QueueProcessor.httpMethodIsQueueable(queuedRequest.getMethod())) {
+            log.warn("Ignore enqueue of unsupported HTTP method in '{} {}'.", queuedRequest.getMethod(), queuedRequest.getUri());
+            if (doneHandler != null) doneHandler.handle(null);
             return;
         }
         vertx.eventBus().send(getRedisquesAddress(), buildEnqueueOperation(queue, queuedRequest.toJsonObject().put(QUEUE_TIMESTAMP, System.currentTimeMillis()).encode()),


### PR DESCRIPTION
- Accept only whitelisted HTTP methods on listener registration which
  namely are: GET, HEAD, PUT, POST, DELETE, OPTIONS and PATCH.
- Respond with a HTTP 400 in case a not whitelisted method got used.
- Document possible exceptions on public API.
- Drop enqueueing requests with non-processable HTTP methods and log
  that attempt.

Fixes #249 .