### PR TITLE
Update to Vertx 3.6.2

### DIFF
--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/AbstractHttpClient.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/AbstractHttpClient.java
@@ -519,6 +519,11 @@ public abstract class AbstractHttpClient implements HttpClient {
     }
 
     @Override
+    public HttpClient connectionHandler(Handler<HttpConnection> handler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public HttpClientRequest request(HttpMethod method, RequestOptions options) {
         throw new UnsupportedOperationException();
     }

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/DummyHttpServerRequest.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/DummyHttpServerRequest.java
@@ -11,7 +11,7 @@ import javax.security.cert.X509Certificate;
  *
  * @author https://github.com/mcweba [Marc-Andre Weber]
  */
-public class DummyHttpServerRequest extends FastFailHttpServerRequest {
+public class DummyHttpServerRequest implements FastFailHttpServerRequest {
 
     @Override public boolean isSSL() { return false; }
 

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/DummyHttpServerResponse.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/DummyHttpServerResponse.java
@@ -2,20 +2,20 @@ package org.swisspush.gateleen.core.http;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 
 /**
  * Dummy class implementing {@link HttpServerResponse}. Override this class for your needs.
  *
  * @author https://github.com/mcweba [Marc-Andre Weber]
  */
-public class DummyHttpServerResponse extends FastFailHttpServerResponse {
+public class DummyHttpServerResponse implements FastFailHttpServerResponse {
     private int statusCode;
     private String statusMessage;
     private String resultBuffer;
 
-    private MultiMap headers = new CaseInsensitiveHeaders();
+    private VertxHttpHeaders headers = new VertxHttpHeaders();
 
     public String getResultBuffer(){
         return resultBuffer;

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/FastFaiHttpClientResponse.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/FastFaiHttpClientResponse.java
@@ -1,0 +1,114 @@
+package org.swisspush.gateleen.core.http;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
+import io.vertx.core.net.NetSocket;
+
+import java.util.List;
+
+public interface FastFaiHttpClientResponse extends HttpClientResponse {
+
+    String msg = "Do override this method to mock expected behaviour.";
+
+    default HttpClientResponse fetch(long amount) {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default HttpClientResponse resume() {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default HttpClientResponse exceptionHandler(Handler<Throwable> handler) {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default HttpClientResponse handler(Handler<Buffer> handler) {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default HttpClientResponse pause() {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default HttpClientResponse endHandler(Handler<Void> endHandler) {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default HttpVersion version() {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default int statusCode() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default String statusMessage() {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default MultiMap headers() {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default @Nullable String getHeader(String headerName) {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default String getHeader(CharSequence headerName) {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default @Nullable String getTrailer(String trailerName) {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default MultiMap trailers() {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default List<String> cookies() {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default HttpClientResponse bodyHandler(Handler<Buffer> bodyHandler) {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default HttpClientResponse customFrameHandler(Handler<HttpFrame> handler) {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default NetSocket netSocket() {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default HttpClientRequest request() {
+        throw new UnsupportedOperationException(msg);
+
+    }
+
+    default HttpClientResponse streamPriorityHandler(Handler<StreamPriority> handler) {
+        throw new UnsupportedOperationException(msg);
+
+    }
+}

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/FastFailHttpClientRequest.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/FastFailHttpClientRequest.java
@@ -1,0 +1,184 @@
+package org.swisspush.gateleen.core.http;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
+
+public interface FastFailHttpClientRequest extends HttpClientRequest {
+
+    String msg = "Do override this method to mock expected behaviour.";
+
+    default HttpClientRequest exceptionHandler(Handler<Throwable> handler) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest write(Buffer data) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest setWriteQueueMaxSize(int maxSize) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default boolean writeQueueFull() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest drainHandler(Handler<Void> handler) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest handler(Handler<HttpClientResponse> handler) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest pause() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest resume() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest fetch(long amount) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest endHandler(Handler<Void> endHandler) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest setFollowRedirects(boolean followRedirects) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest setChunked(boolean chunked) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default boolean isChunked() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpMethod method() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default String getRawMethod() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest setRawMethod(String method) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default String absoluteURI() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default String uri() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default String path() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default String query() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest setHost(String host) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default String getHost() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default MultiMap headers() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest putHeader(String name, String value) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest putHeader(CharSequence name, CharSequence value) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest putHeader(String name, Iterable<String> values) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest putHeader(CharSequence name, Iterable<CharSequence> values) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest write(String chunk) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest write(String chunk, String enc) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest continueHandler(@Nullable Handler<Void> handler) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest sendHead() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest sendHead(Handler<HttpVersion> completionHandler) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default void end(String chunk) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default void end(String chunk, String enc) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default void end(Buffer chunk) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default void end() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest setTimeout(long timeoutMs) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest pushHandler(Handler<HttpClientRequest> handler) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default boolean reset(long code) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpConnection connection() {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest connectionHandler(@Nullable Handler<HttpConnection> handler) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default HttpClientRequest writeCustomFrame(int type, int flags, Buffer payload) {
+        throw new UnsupportedOperationException(msg);
+    }
+
+    default StreamPriority getStreamPriority() {
+        throw new UnsupportedOperationException(msg);
+    }
+}

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/FastFailHttpServerRequest.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/FastFailHttpServerRequest.java
@@ -22,183 +22,160 @@ import javax.security.cert.X509Certificate;
  * methods you need to mock.
  *
  */
-public class FastFailHttpServerRequest implements HttpServerRequest {
+public interface FastFailHttpServerRequest extends HttpServerRequest {
 
-    private static final String msg = "Mock: Override this method to mock your expected behaviour.";
+    String msg = "Mock: Override this method to mock your expected behaviour.";
 
 
-    @Override
-    public HttpServerRequest exceptionHandler(Handler<Throwable> handler) {
+    default HttpServerRequest exceptionHandler(Handler<Throwable> handler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerRequest handler(Handler<Buffer> handler) {
+    default HttpServerRequest handler(Handler<Buffer> handler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerRequest pause() {
+    default HttpServerRequest pause() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerRequest resume() {
+    default HttpServerRequest resume() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerRequest endHandler(Handler<Void> endHandler) {
+    default HttpServerRequest fetch(long amount) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpVersion version() {
+    default HttpServerRequest endHandler(Handler<Void> endHandler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpMethod method() {
+    default HttpVersion version() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public String rawMethod() {
+    default HttpMethod method() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public boolean isSSL() {
+    default String rawMethod() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public @Nullable String scheme() {
+    default boolean isSSL() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public String uri() {
+    default @Nullable String scheme() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public @Nullable String path() {
+    default String uri() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public @Nullable String query() {
+    default @Nullable String path() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public @Nullable String host() {
+    default @Nullable String query() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse response() {
+    default @Nullable String host() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public MultiMap headers() {
+    default long bytesRead() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public @Nullable String getHeader(String headerName) {
+    default HttpServerResponse response() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public String getHeader(CharSequence headerName) {
+    default MultiMap headers() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public MultiMap params() {
+    default @Nullable String getHeader(String headerName) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public @Nullable String getParam(String paramName) {
+    default String getHeader(CharSequence headerName) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public SocketAddress remoteAddress() {
+    default MultiMap params() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public SocketAddress localAddress() {
+    default @Nullable String getParam(String paramName) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public SSLSession sslSession() {
+    default SocketAddress remoteAddress() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+    default SocketAddress localAddress() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public String absoluteURI() {
+    default SSLSession sslSession() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public NetSocket netSocket() {
+    default X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerRequest setExpectMultipart(boolean expect) {
+    default String absoluteURI() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public boolean isExpectMultipart() {
+    default NetSocket netSocket() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerRequest uploadHandler(@Nullable Handler<HttpServerFileUpload> uploadHandler) {
+    default HttpServerRequest setExpectMultipart(boolean expect) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public MultiMap formAttributes() {
+    default boolean isExpectMultipart() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public @Nullable String getFormAttribute(String attributeName) {
+    default HttpServerRequest uploadHandler(@Nullable Handler<HttpServerFileUpload> uploadHandler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public ServerWebSocket upgrade() {
+    default MultiMap formAttributes() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public boolean isEnded() {
+    default @Nullable String getFormAttribute(String attributeName) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerRequest customFrameHandler(Handler<HttpFrame> handler) {
+    default ServerWebSocket upgrade() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpConnection connection() {
+    default boolean isEnded() {
+        throw new UnsupportedOperationException( msg );
+    }
+
+    default HttpServerRequest customFrameHandler(Handler<HttpFrame> handler) {
+        throw new UnsupportedOperationException( msg );
+    }
+
+    default HttpConnection connection() {
+        throw new UnsupportedOperationException( msg );
+    }
+
+    default HttpServerRequest streamPriorityHandler(Handler<StreamPriority> handler) {
         throw new UnsupportedOperationException( msg );
     }
 }

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/FastFailHttpServerResponse.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/FastFailHttpServerResponse.java
@@ -19,237 +19,191 @@ import io.vertx.core.http.HttpServerResponse;
  * methods you need to mock.
  *
  */
-public class FastFailHttpServerResponse implements HttpServerResponse {
+public interface FastFailHttpServerResponse extends HttpServerResponse {
 
-    private static final String msg = "Do override this method to mock expected behaviour.";
+    String msg = "Do override this method to mock expected behaviour.";
 
-    @Override
-    public HttpServerResponse exceptionHandler(Handler<Throwable> handler) {
+    default HttpServerResponse exceptionHandler(Handler<Throwable> handler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse write(Buffer data) {
+    default HttpServerResponse write(Buffer data) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse setWriteQueueMaxSize(int maxSize) {
+    default HttpServerResponse setWriteQueueMaxSize(int maxSize) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public boolean writeQueueFull() {
+    default boolean writeQueueFull() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse drainHandler(Handler<Void> handler) {
+    default HttpServerResponse drainHandler(Handler<Void> handler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public int getStatusCode() {
+    default int getStatusCode() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse setStatusCode(int statusCode) {
+    default HttpServerResponse setStatusCode(int statusCode) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public String getStatusMessage() {
+    default String getStatusMessage() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse setStatusMessage(String statusMessage) {
+    default HttpServerResponse setStatusMessage(String statusMessage) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse setChunked(boolean chunked) {
+    default HttpServerResponse setChunked(boolean chunked) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public boolean isChunked() {
+    default boolean isChunked() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public MultiMap headers() {
+    default MultiMap headers() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse putHeader(String name, String value) {
+    default HttpServerResponse putHeader(String name, String value) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse putHeader(CharSequence name, CharSequence value) {
+    default HttpServerResponse putHeader(CharSequence name, CharSequence value) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse putHeader(String name, Iterable<String> values) {
+    default HttpServerResponse putHeader(String name, Iterable<String> values) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse putHeader(CharSequence name, Iterable<CharSequence> values) {
+    default HttpServerResponse putHeader(CharSequence name, Iterable<CharSequence> values) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public MultiMap trailers() {
+    default MultiMap trailers() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse putTrailer(String name, String value) {
+    default HttpServerResponse putTrailer(String name, String value) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse putTrailer(CharSequence name, CharSequence value) {
+    default HttpServerResponse putTrailer(CharSequence name, CharSequence value) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse putTrailer(String name, Iterable<String> values) {
+    default HttpServerResponse putTrailer(String name, Iterable<String> values) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse putTrailer(CharSequence name, Iterable<CharSequence> value) {
+    default HttpServerResponse putTrailer(CharSequence name, Iterable<CharSequence> value) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse closeHandler(@Nullable Handler<Void> handler) {
+    default HttpServerResponse closeHandler(@Nullable Handler<Void> handler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse endHandler(@Nullable Handler<Void> handler) {
+    default HttpServerResponse endHandler(@Nullable Handler<Void> handler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse write(String chunk, String enc) {
+    default HttpServerResponse write(String chunk, String enc) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse write(String chunk) {
+    default HttpServerResponse write(String chunk) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse writeContinue() {
+    default HttpServerResponse writeContinue() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public void end(String chunk) {
+    default void end(String chunk) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public void end(String chunk, String enc) {
+    default void end(String chunk, String enc) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public void end(Buffer chunk) {
+    default void end(Buffer chunk) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public void end() {
+    default void end() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse sendFile(String filename, long offset, long length) {
+    default HttpServerResponse sendFile(String filename, long offset, long length) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse sendFile(String filename, long offset, long length, Handler<AsyncResult<Void>> resultHandler) {
+    default HttpServerResponse sendFile(String filename, long offset, long length, Handler<AsyncResult<Void>> resultHandler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public void close() {
+    default void close() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public boolean ended() {
+    default boolean ended() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public boolean closed() {
+    default boolean closed() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public boolean headWritten() {
+    default boolean headWritten() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse headersEndHandler(@Nullable Handler<Void> handler) {
+    default HttpServerResponse headersEndHandler(@Nullable Handler<Void> handler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse bodyEndHandler(@Nullable Handler<Void> handler) {
+    default HttpServerResponse bodyEndHandler(@Nullable Handler<Void> handler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public long bytesWritten() {
+    default long bytesWritten() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public int streamId() {
+    default int streamId() {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse push(HttpMethod method, String host, String path, Handler<AsyncResult<HttpServerResponse>> handler) {
+    default HttpServerResponse push(HttpMethod method, String host, String path, Handler<AsyncResult<HttpServerResponse>> handler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse push(HttpMethod method, String path, MultiMap headers, Handler<AsyncResult<HttpServerResponse>> handler) {
+    default HttpServerResponse push(HttpMethod method, String path, MultiMap headers, Handler<AsyncResult<HttpServerResponse>> handler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse push(HttpMethod method, String path, Handler<AsyncResult<HttpServerResponse>> handler) {
+    default HttpServerResponse push(HttpMethod method, String path, Handler<AsyncResult<HttpServerResponse>> handler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse push(HttpMethod method, String host, String path, MultiMap headers, Handler<AsyncResult<HttpServerResponse>> handler) {
+    default HttpServerResponse push(HttpMethod method, String host, String path, MultiMap headers, Handler<AsyncResult<HttpServerResponse>> handler) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public void reset(long code) {
+    default void reset(long code) {
         throw new UnsupportedOperationException( msg );
     }
 
-    @Override
-    public HttpServerResponse writeCustomFrame(int type, int flags, Buffer payload) {
+    default HttpServerResponse writeCustomFrame(int type, int flags, Buffer payload) {
         throw new UnsupportedOperationException( msg );
     }
 }

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/LocalHttpServerResponse.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/LocalHttpServerResponse.java
@@ -1,38 +1,34 @@
 package org.swisspush.gateleen.core.http;
 
-import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
-import io.vertx.core.net.NetSocket;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.swisspush.gateleen.core.util.StatusCode;
-
-import java.util.List;
 
 /**
  * Bridges the reponses of a LocalHttpClientRequest.
  *
  * @author https://github.com/lbovet [Laurent Bovet]
  */
-public class LocalHttpServerResponse extends BufferBridge implements HttpServerResponse {
+public class LocalHttpServerResponse extends BufferBridge implements FastFailHttpServerResponse {
 
     private static final Logger logger = LoggerFactory.getLogger(LocalHttpServerResponse.class);
     private int statusCode;
     private String statusMessage;
     private static final String EMPTY = "";
     private Handler<HttpClientResponse> responseHandler;
-    private MultiMap headers = new CaseInsensitiveHeaders();
+    private MultiMap headers = new VertxHttpHeaders();
     private boolean chunked = false;
     private boolean bound = false;
     private boolean closed = false;
     private boolean written = false;
 
-    private HttpClientResponse clientResponse = new HttpClientResponse() {
+    private HttpClientResponse clientResponse = new FastFaiHttpClientResponse () {
         @Override
         public int statusCode() {
             return statusCode;
@@ -67,21 +63,6 @@ public class LocalHttpServerResponse extends BufferBridge implements HttpServerR
         }
 
         @Override
-        public String getTrailer(String trailerName) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public MultiMap trailers() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public List<String> cookies() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public HttpClientResponse bodyHandler(final Handler<Buffer> bodyHandler) {
             final Buffer body = Buffer.buffer();
             handler(body::appendBuffer);
@@ -93,11 +74,6 @@ public class LocalHttpServerResponse extends BufferBridge implements HttpServerR
         public HttpClientResponse customFrameHandler(Handler<HttpFrame> handler) { return this; }
 
         @Override
-        public NetSocket netSocket() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public HttpClientRequest request() {
             return null;
         }
@@ -107,9 +83,6 @@ public class LocalHttpServerResponse extends BufferBridge implements HttpServerR
             setEndHandler(handler);
             return this;
         }
-
-        @Override
-        public HttpVersion version() { throw new UnsupportedOperationException(); }
 
         @Override
         public HttpClientResponse handler(Handler<Buffer> handler) {
@@ -221,38 +194,8 @@ public class LocalHttpServerResponse extends BufferBridge implements HttpServerR
     }
 
     @Override
-    public MultiMap trailers() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse putTrailer(String name, String value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse putTrailer(CharSequence name, CharSequence value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse putTrailer(String name, Iterable<String> values) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse putTrailer(CharSequence name, Iterable<CharSequence> value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public HttpServerResponse closeHandler(Handler<Void> handler) {
         return this;
-    }
-
-    @Override
-    public HttpServerResponse endHandler(@Nullable Handler<Void> handler) {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -296,11 +239,6 @@ public class LocalHttpServerResponse extends BufferBridge implements HttpServerR
     }
 
     @Override
-    public HttpServerResponse writeContinue() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void end(String chunk) {
         end(Buffer.buffer(chunk));
     }
@@ -332,31 +270,6 @@ public class LocalHttpServerResponse extends BufferBridge implements HttpServerR
     }
 
     @Override
-    public HttpServerResponse sendFile(String filename) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse sendFile(String filename, long offset) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse sendFile(String filename, long offset, long length) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse sendFile(String filename, Handler<AsyncResult<Void>> resultHandler) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse sendFile(String filename, long offset, long length, Handler<AsyncResult<Void>> resultHandler) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void close() {
         // makes not really sense as we have no underlying TCP connection which can be closed
         // nevertheless we simulate the behaviour of a 'real' HttpServerResponse
@@ -382,54 +295,6 @@ public class LocalHttpServerResponse extends BufferBridge implements HttpServerR
     }
 
     @Override
-    public HttpServerResponse headersEndHandler(Handler<Void> handler) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse bodyEndHandler(Handler<Void> handler) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public long bytesWritten() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int streamId() { throw new UnsupportedOperationException(); }
-
-    @Override
-    public HttpServerResponse push(HttpMethod method, String host, String path, Handler<AsyncResult<HttpServerResponse>> handler) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse push(HttpMethod method, String path, MultiMap headers, Handler<AsyncResult<HttpServerResponse>> handler) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse push(HttpMethod method, String path, Handler<AsyncResult<HttpServerResponse>> handler) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse push(HttpMethod method, String host, String path, MultiMap headers, Handler<AsyncResult<HttpServerResponse>> handler) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void reset(long code) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public HttpServerResponse writeCustomFrame(int type, int flags, Buffer payload) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public HttpServerResponse setWriteQueueMaxSize(int maxSize) {
         return this;
     }
@@ -437,11 +302,6 @@ public class LocalHttpServerResponse extends BufferBridge implements HttpServerR
     @Override
     public boolean writeQueueFull() {
         return false;
-    }
-
-    @Override
-    public HttpServerResponse drainHandler(Handler<Void> handler) {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/gateleen-delegate/src/main/java/org/swisspush/gateleen/delegate/Delegate.java
+++ b/gateleen-delegate/src/main/java/org/swisspush/gateleen/delegate/Delegate.java
@@ -2,9 +2,9 @@ package org.swisspush.gateleen.delegate;
 
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.slf4j.Logger;
@@ -138,7 +138,7 @@ public class Delegate {
             final String requestUri = matcher.replaceAll(requestObject.getString(URI));
 
             // headers of the delegate
-            MultiMap headers = new CaseInsensitiveHeaders();
+            VertxHttpHeaders headers = new VertxHttpHeaders();
             JsonArray headersArray = requestObject.getJsonArray(HEADERS);
             if (headersArray != null) {
                 if (LOG.isTraceEnabled()) {

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -6,11 +6,11 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.ValidationMessage;
 import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.*;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -707,7 +707,7 @@ public class HookHandler implements LoggableResource {
 
             // Create a new multimap, copied from the original request,
             // so that the original request is not overridden with the new values.
-            MultiMap queueHeaders = new CaseInsensitiveHeaders();
+            VertxHttpHeaders queueHeaders = new VertxHttpHeaders();
             queueHeaders.addAll(request.headers());
 
             // Apply the header manipulation chain - errors (unresolvable references) will just be WARN logged - but we still enqueue
@@ -815,7 +815,7 @@ public class HookHandler implements LoggableResource {
                         route.forward(request, buffer);
                     } else {
                         // mark the original request as hooked
-                        request.headers().add(HOOKED_HEADER, "true");
+                        request.headers().set(HOOKED_HEADER, "true");
 
                         /*
                          * self requests are only made for original

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/NullForwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/NullForwarder.java
@@ -4,8 +4,8 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBus;
-import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.swisspush.gateleen.core.http.HeaderFunctions;
@@ -41,7 +41,7 @@ public class NullForwarder implements Handler<RoutingContext> {
         final LoggingHandler loggingHandler = new LoggingHandler(loggingResourceManager, ctx.request(), eventBus);
         final Logger log = RequestLoggerFactory.getLogger(NullForwarder.class, ctx.request());
         log.debug("Not forwarding request: " + ctx.request().uri() + " with rule " + rule.getRuleIdentifier());
-        final MultiMap requestHeaders = new CaseInsensitiveHeaders();
+        final VertxHttpHeaders requestHeaders = new VertxHttpHeaders();
         requestHeaders.addAll(ctx.request().headers());
 
         // probably useless, as the request is discarded anyway
@@ -76,7 +76,7 @@ public class NullForwarder implements Handler<RoutingContext> {
             loggingHandler.appendRequestPayload(buffer, requestHeaders);
             requestBuffer.appendBuffer(buffer);
             MultiMap responseHeaders = ctx.response().headers();
-            loggingHandler.log(ctx.request().uri(), ctx.request().method(), statusCode, statusMessage, requestHeaders, responseHeaders != null ? responseHeaders : new CaseInsensitiveHeaders());
+            loggingHandler.log(ctx.request().uri(), ctx.request().method(), statusCode, statusMessage, requestHeaders, responseHeaders != null ? responseHeaders : new VertxHttpHeaders());
         });
 
         ctx.response().end();

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/StorageForwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/StorageForwarder.java
@@ -7,8 +7,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
-import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -61,7 +61,7 @@ public class StorageForwarder implements Handler<RoutingContext> {
         monitoringHandler.updateRequestPerRuleMonitoring(ctx.request(), rule.getMetricName());
         final long startTime = monitoringHandler.startRequestMetricTracking(rule.getMetricName(), ctx.request().uri());
         log.debug("Forwarding request: " + ctx.request().uri() + " to storage " + rule.getStorage() + " " + targetUri + " with rule " + rule.getRuleIdentifier());
-        final MultiMap requestHeaders = new CaseInsensitiveHeaders();
+        final VertxHttpHeaders requestHeaders = new VertxHttpHeaders();
         requestHeaders.addAll(ctx.request().headers());
 
         final HeaderFunctions.EvalScope evalScope = rule.getHeaderFunction().apply(requestHeaders);// Apply the header manipulation chain
@@ -134,7 +134,7 @@ public class StorageForwarder implements Handler<RoutingContext> {
                             loggingHandler.appendResponsePayload(data, responseHeaders);
                         }
                         loggingHandler.log(ctx.request().uri(), ctx.request().method(), statusCode, statusMessage,
-                                requestHeaders, responseHeaders != null ? responseHeaders : new CaseInsensitiveHeaders());
+                                requestHeaders, responseHeaders != null ? responseHeaders : new VertxHttpHeaders());
                     }
                 }));
     }

--- a/gateleen-validation/src/test/java/org/swisspush/gateleen/validation/mocks/HttpServerRequestMock.java
+++ b/gateleen-validation/src/test/java/org/swisspush/gateleen/validation/mocks/HttpServerRequestMock.java
@@ -7,9 +7,9 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
+import org.swisspush.gateleen.core.http.FastFailHttpServerRequest;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 
 /**
@@ -17,7 +17,7 @@ import javax.security.cert.X509Certificate;
  *
  * @author https://github.com/mcweba [Marc-Andre Weber]
  */
-public class HttpServerRequestMock implements HttpServerRequest {
+public class HttpServerRequestMock implements FastFailHttpServerRequest {
 
     private String bodyContent;
 
@@ -108,11 +108,6 @@ public class HttpServerRequestMock implements HttpServerRequest {
     @Override
     public SocketAddress localAddress() {
         return null;
-    }
-
-    @Override
-    public SSLSession sslSession() {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <targetPort>8989</targetPort>
         <sel_chrome_driver>${session.executionRootDirectory}/gateleen-test/src/test/resources/chromedriver
         </sel_chrome_driver>
-        <vertx.version>3.5.3</vertx.version>
+        <vertx.version>3.6.2</vertx.version>
         <jackson.version>2.9.8</jackson.version>
     </properties>
 


### PR DESCRIPTION
Some implementation notes:
- Gateleen implements a few core Vertx interfaces for its "SelfClient" (i.e. `... implements Http(Server|Client)(Request|Response)`).
  Those interfaces are often updated/extended from one Vertx-Version to the next one. It's always a mess to update the implementations with a bunch of "throw new UnsupportedOperationException(msg);"
  Therefor we now have interfaces (`FastFailHttp....`) with default-implementations (java 8 feature). This moves a lot of boiler plate code away from the main worker classes
- Migrate some core classes from Vertx class `CaseInsensitiveHeaders` to `VertxHttpHeaders`. This is a simple 1:1 replacement and is a faster implementation (according to Vert.x Guru Julien Viet)
- Due to a changed behaviour in HttpHeader when reading a 'single value' if 'multiple values are around' (see https://github.com/eclipse-vertx/vert.x/issues/2688) we need to fix the "x-hooked" indicator in HookHandler: We now "set" and do not "add" to prevent multiple "x-hooked" in the Self-Request
- A changed behaviour in "HttpServerRequest.ended" in Vertx 3.6 (https://github.com/eclipse-vertx/vert.x/issues/2763) requires us to check 'isEnded' before we install an endHandler (in Gateleen's `Forwarder`)