### PR TITLE
Discontinued to use LocalDateTime because of issues upon timezone change

### DIFF
--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HttpHook.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HttpHook.java
@@ -1,7 +1,7 @@
 package org.swisspush.gateleen.hook;
 
 import io.vertx.core.net.ProxyOptions;
-import org.joda.time.LocalDateTime;
+import org.joda.time.DateTime;
 import org.swisspush.gateleen.core.http.HeaderFunction;
 import org.swisspush.gateleen.core.http.HeaderFunctions;
 import org.swisspush.gateleen.hook.queueingstrategy.DefaultQueueingStrategy;
@@ -23,7 +23,7 @@ public class HttpHook {
     public static final int CONNECTION_POOL_SIZE_DEFAULT_VALUE = Rule.CONNECTION_POOL_SIZE_DEFAULT_VALUE;
     private String destination;
     private List<String> methods;
-    private LocalDateTime expirationTime;
+    private DateTime expirationTime;
     private boolean fullUrl = false;
     private QueueingStrategy queueingStrategy = new DefaultQueueingStrategy();
     private Pattern filter = null;
@@ -88,7 +88,7 @@ public class HttpHook {
      *      Expiration time of this hook. This is null for hooks with infinite
      *      expiration.
      */
-    public Optional<LocalDateTime> getExpirationTime() {
+    public Optional<DateTime> getExpirationTime() {
         return Optional.ofNullable( expirationTime );
     }
 
@@ -97,7 +97,7 @@ public class HttpHook {
      * 
      * @param expirationTime expirationTime
      */
-    public void setExpirationTime(LocalDateTime expirationTime) {
+    public void setExpirationTime(DateTime expirationTime) {
         this.expirationTime = expirationTime;
     }
 

--- a/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
+++ b/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
@@ -319,12 +319,12 @@ public class HookHandlerTest {
         // Assert request was ok
         testContext.assertEquals(200, statusCodePtr[0]);
 
-        { // Assert expiration time has same length as a valid date.
+        { // Assert expiration time has same length as a valid date (including time zone)
             final String storedHook = storage.getMockData().get(HOOK_ROOT_URI + "registrations/listeners/http+my-service+my-hook+gateleen+example");
             testContext.assertNotNull(storedHook);
             final String expirationTime = new JsonObject(storedHook).getString("expirationTime");
             testContext.assertNotNull(expirationTime);
-            testContext.assertEquals("____-__-__T__:__:__.___".length(), expirationTime.length());
+            testContext.assertEquals("____-__-__T__:__:__.___+__:__".length(), expirationTime.length());
         }
     }
 
@@ -353,12 +353,12 @@ public class HookHandlerTest {
         // Assert request was ok
         testContext.assertEquals(200, statusCodePtr[0]);
 
-        { // Assert expiration time has same length as a valid date.
+        { // Assert expiration time has same length as a valid date (including time zone)
             final String storedHook = storage.getMockData().get(HOOK_ROOT_URI + "registrations/listeners/http+my-service+my-fancy-hook+gateleen+example");
             testContext.assertNotNull(storedHook);
             final String expirationTime = new JsonObject(storedHook).getString("expirationTime");
             testContext.assertNotNull(expirationTime);
-            testContext.assertEquals("____-__-__T__:__:__.___".length(), expirationTime.length());
+            testContext.assertEquals("____-__-__T__:__:__.___+__:__".length(), expirationTime.length());
         }
     }
 
@@ -383,12 +383,12 @@ public class HookHandlerTest {
         // Assert request was ok
         testContext.assertEquals(200, statusCodePtr[0]);
 
-        { // Assert expiration time has same length as a valid date.
+        { // Assert expiration time has same length as a valid date (including timezone)
             final String storedHook = storage.getMockData().get(HOOK_ROOT_URI + "registrations/listeners/http+my-service+yet-another-hook+gateleen+example");
             testContext.assertNotNull(storedHook);
             final String expirationTime = new JsonObject(storedHook).getString("expirationTime");
             testContext.assertNotNull(expirationTime);
-            testContext.assertEquals("____-__-__T__:__:__.___".length(), expirationTime.length());
+            testContext.assertEquals("____-__-__T__:__:__.___+__:__".length(), expirationTime.length());
         }
     }
 

--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueueClient.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueueClient.java
@@ -183,9 +183,9 @@ public class QueueClient implements RequestQueue {
     }
 
     /**
-     * Enques a request. <br />
+     * Enqueues a request. <br />
      * If no X-Server-Timestamp and / or X-Expire-After headers
-     * are set, the server sets the actual timestamp and a default
+     * are set, the server sets the current timestamp and a default
      * expiry time of 2 seconds.
      *
      * @param request       - a client made request, therefor connected, can take responses. The request can be null, if only a selfmade request is available.
@@ -197,9 +197,9 @@ public class QueueClient implements RequestQueue {
     }
 
     /**
-     * Enques a request. <br />
+     * Enqueues a request. <br />
      * If no X-Server-Timestamp and / or X-Expire-After headers
-     * are set, the server sets the actual timestamp and a default
+     * are set, the server sets the current timestamp and a default
      * expiry time of 2 seconds.
      *
      * @param request       - a client made request, therefor connected, can take responses. The request can be null, if only a selfmade request is available.

--- a/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/expiry/ExpiryCheckHandlerTest.java
+++ b/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/expiry/ExpiryCheckHandlerTest.java
@@ -4,6 +4,8 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.MultiMap;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.joda.time.DateTime;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.swisspush.gateleen.core.util.FastFailMultiMap;
@@ -252,6 +254,15 @@ public class ExpiryCheckHandlerTest {
         ExpiryCheckHandler.getExpireAfterConcerningCaseOfCorruptHeaderAndInfinite(headers);
     }
 
+    @Test
+    public void parseDateTimeTest() {
+        DateTime parsed = ExpiryCheckHandler.parseDateTime("2020-03-05T10:21:27.021+01:00");
+        Assert.assertEquals(1583400087021L, parsed.getMillis());
+
+        // CET is assumed if timezone is missing
+        DateTime parsedWithoutTimezone = ExpiryCheckHandler.parseDateTime("2020-03-05T10:21:27.021");
+        Assert.assertEquals(1583400087021L, parsedWithoutTimezone.getMillis());
+    }
 
     ///////////////////////////////////////////////////////////////////////////////
     // Below some helper methods like factories etc. to share code in tests.


### PR DESCRIPTION
The route hooks currently expire we we enter daylight savings time (and probably do not expire on time when we leave daylight savings time). With this PR we use DateTime (which is timezone aware) to avoid such issues. 

I also removed some not used code.