### PR TITLE
#331 Parse delta response as long

### DIFF
--- a/gateleen-expansion/src/main/java/org/swisspush/gateleen/expansion/RecursiveExpansionHandler.java
+++ b/gateleen-expansion/src/main/java/org/swisspush/gateleen/expansion/RecursiveExpansionHandler.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * A class for handeling the recursive get request.
@@ -31,7 +32,7 @@ public class RecursiveExpansionHandler implements DeltaHandler<ResourceNode> {
     private Map<String, ResourceNode> nodeMap;
     private String collectioneTag;
     private Map<String, ResourceCollectionException> resourceCollectionExceptionMap;
-    private AtomicInteger xDeltaResponseNumber;
+    private AtomicLong xDeltaResponseNumber;
 
     /**
      * Creates a new instance of the RecursiveExpansionHandler.
@@ -46,7 +47,7 @@ public class RecursiveExpansionHandler implements DeltaHandler<ResourceNode> {
             log.trace("RecursiveExpansionHandler created for collection '" + collectionName + "' with a child count of " + subResourceNames.size() + ".");
         }
 
-        this.xDeltaResponseNumber = new AtomicInteger(0);
+        this.xDeltaResponseNumber = new AtomicLong(0);
         this.processCount = new AtomicInteger(subResourceNames.size());
         this.parentHandler = parentHandler;
         this.collectionName = collectionName;
@@ -208,14 +209,14 @@ public class RecursiveExpansionHandler implements DeltaHandler<ResourceNode> {
 
             try {
                 // try to parse it
-                int tempxDeltaResponseNumber = Integer.parseInt(xDeltaResponseNumber);
+                long tempxDeltaResponseNumber = Long.parseLong(xDeltaResponseNumber);
 
                 // compare numbers
                 if (this.xDeltaResponseNumber.get() < tempxDeltaResponseNumber) {
                     this.xDeltaResponseNumber.set(tempxDeltaResponseNumber);
                 }
             } catch (NumberFormatException e) {
-                // ignored
+                log.warn("Delta response value was not a number", e);
             }
         }
     }

--- a/gateleen-expansion/src/main/java/org/swisspush/gateleen/expansion/RecursiveRootHandlerBase.java
+++ b/gateleen-expansion/src/main/java/org/swisspush/gateleen/expansion/RecursiveRootHandlerBase.java
@@ -8,7 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * The base class of the root handler for
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public abstract class RecursiveRootHandlerBase implements DeltaHandler<ResourceNode> {
     protected static final Logger log = LoggerFactory.getLogger(RecursiveRootHandlerBase.class);
-    protected AtomicInteger xDeltaResponseNumber = new AtomicInteger(0);
+    protected AtomicLong xDeltaResponseNumber = new AtomicLong(0);
 
     /**
      * Handles a response error.
@@ -80,14 +80,14 @@ public abstract class RecursiveRootHandlerBase implements DeltaHandler<ResourceN
 
             try {
                 // try to parse it
-                int tempxDeltaResponseNumber = Integer.parseInt(xDeltaResponseNumber);
+                long tempxDeltaResponseNumber = Long.parseLong(xDeltaResponseNumber);
 
                 // compare numbers
                 if (this.xDeltaResponseNumber.get() < tempxDeltaResponseNumber) {
                     this.xDeltaResponseNumber.set(tempxDeltaResponseNumber);
                 }
             } catch (NumberFormatException e) {
-                // ignored
+                log.warn("Delta response value was not a number", e);
             }
         }
     }

--- a/gateleen-expansion/src/main/java/org/swisspush/gateleen/expansion/RecursiveZipHandler.java
+++ b/gateleen-expansion/src/main/java/org/swisspush/gateleen/expansion/RecursiveZipHandler.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * A handler that allows to put all handeld Json Resources to a zip stream.
@@ -25,7 +26,7 @@ public class RecursiveZipHandler implements DeltaHandler<ResourceNode> {
     private AtomicInteger processCount;
     private DeltaHandler<ResourceNode> parentHandler;
     private List<ResourceNode> nodes;
-    private AtomicInteger xDeltaResponseNumber;
+    private AtomicLong xDeltaResponseNumber;
 
     /**
      * Creates an new instance of the RecursiveZipHandler.
@@ -39,7 +40,7 @@ public class RecursiveZipHandler implements DeltaHandler<ResourceNode> {
         this.collectionName = collectionName;
         processCount = new AtomicInteger(subResourceNames.size());
         nodes = new ArrayList<>();
-        xDeltaResponseNumber = new AtomicInteger(0);
+        xDeltaResponseNumber = new AtomicLong(0);
     }
 
     @SuppressWarnings("unchecked")
@@ -121,14 +122,14 @@ public class RecursiveZipHandler implements DeltaHandler<ResourceNode> {
 
             try {
                 // try to parse it
-                int tempxDeltaResponseNumber = Integer.parseInt(xDeltaResponseNumber);
+                long tempxDeltaResponseNumber = Long.parseLong(xDeltaResponseNumber);
 
                 // compare numbers
                 if (this.xDeltaResponseNumber.get() < tempxDeltaResponseNumber) {
                     this.xDeltaResponseNumber.set(tempxDeltaResponseNumber);
                 }
             } catch (NumberFormatException e) {
-                // ignored
+                log.warn("Delta response value was not a number", e);
             }
         }
     }


### PR DESCRIPTION
To avoid an overflow, the delta response value should be parsed as long and not as integer.