### PR TITLE
warning log when failing to send kafka message

### DIFF
--- a/gateleen-kafka/src/main/java/org/swisspush/gateleen/kafka/KafkaMessageSender.java
+++ b/gateleen-kafka/src/main/java/org/swisspush/gateleen/kafka/KafkaMessageSender.java
@@ -42,7 +42,7 @@ public class KafkaMessageSender {
                 }
                 f.complete();
             } else {
-                log.info("Failed to send message with key '{}' to kafka. Cause: {}", message.key(), event.cause());
+                log.warn("Failed to send message with key '{}' to kafka. Cause: {}", message.key(), event.cause());
                 f.fail(event.cause());
             }
         });


### PR DESCRIPTION
Changing log to warn in failing situations instead of info