### PR TITLE
kafka batching

### DIFF
--- a/gateleen-kafka/src/main/java/org/swisspush/gateleen/kafka/KafkaMessageSender.java
+++ b/gateleen-kafka/src/main/java/org/swisspush/gateleen/kafka/KafkaMessageSender.java
@@ -19,6 +19,7 @@ public class KafkaMessageSender {
         List<Future<Void>> futureList = new ArrayList<>();
 
         for (KafkaProducerRecord<String, String> message : messages) {
+            log.debug("Start processing {} messages for kafka", messages.size());
             Future<Void> futureEntry = sendMessage(kafkaProducer, message);
             futureList.add(futureEntry);
         }
@@ -34,6 +35,7 @@ public class KafkaMessageSender {
 
                    if (remaining[0] == 0) {
                        future.complete();
+                       log.debug("Batch messages successfully sent to kafka.");
                    }
                } else {
                    future.fail(event.cause());

--- a/gateleen-kafka/src/main/java/org/swisspush/gateleen/kafka/KafkaMessageSender.java
+++ b/gateleen-kafka/src/main/java/org/swisspush/gateleen/kafka/KafkaMessageSender.java
@@ -1,56 +1,47 @@
 package org.swisspush.gateleen.kafka;
 
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 public class KafkaMessageSender {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaMessageSender.class);
 
     Future<Void> sendMessages(KafkaProducer<String, String> kafkaProducer,
-                                     List<KafkaProducerRecord<String, String>> messages){
+                              List<KafkaProducerRecord<String, String>> messages) {
         Future<Void> future = Future.future();
-        List<Future<Void>> futureList = new ArrayList<>();
+        log.debug("Start processing {} messages for kafka", messages.size());
 
-        for (KafkaProducerRecord<String, String> message : messages) {
-            log.debug("Start processing {} messages for kafka", messages.size());
-            Future<Void> futureEntry = sendMessage(kafkaProducer, message);
-            futureList.add(futureEntry);
-        }
+        @SuppressWarnings("rawtypes") //https://github.com/eclipse-vertx/vert.x/issues/2627
+        List<Future> futures = messages.stream()
+                .map(message -> KafkaMessageSender.this.sendMessage(kafkaProducer, message))
+                .collect(toList());
 
-        kafkaProducer.flush(event -> {});
-
-        final int[] remaining = {futureList.size()};
-
-        for (Future<Void> voidFuture : futureList) {
-           voidFuture.setHandler(event -> {
-               if (event.succeeded()) {
-                   remaining[0] -= 1;
-
-                   if (remaining[0] == 0) {
-                       future.complete();
-                       log.debug("Batch messages successfully sent to kafka.");
-                   }
-               } else {
-                   future.fail(event.cause());
-               }
-           });
-        }
+        CompositeFuture.all(futures).<Void>mapEmpty().setHandler(result -> {
+            if (result.succeeded()) {
+                future.complete();
+                log.debug("Batch messages successfully sent to Kafka.");
+            } else {
+                future.fail(result.cause());
+            }
+        });
 
         return future;
     }
 
-    private Future<Void> sendMessage(KafkaProducer<String, String> kafkaProducer, KafkaProducerRecord<String, String> message){
+    private Future<Void> sendMessage(KafkaProducer<String, String> kafkaProducer, KafkaProducerRecord<String, String> message) {
         Future<Void> f = Future.future();
         kafkaProducer.write(message, event -> {
-            if(event.succeeded()){
-                if (message.key() != null){
+            if (event.succeeded()) {
+                if (message.key() != null) {
                     log.debug("Message with key '{}' successfully sent to kafka. Result: {}", message.key(), event.result().toJson());
                 } else {
                     log.debug("Message without key successfully sent to kafka. Result: {}", event.result().toJson());

--- a/gateleen-kafka/src/test/java/org/swisspush/gateleen/kafka/KafkaMessageSenderTest.java
+++ b/gateleen-kafka/src/test/java/org/swisspush/gateleen/kafka/KafkaMessageSenderTest.java
@@ -138,12 +138,13 @@ public class KafkaMessageSenderTest {
         });
 
         ArgumentCaptor<KafkaProducerRecord> recordCaptor = ArgumentCaptor.forClass(KafkaProducerRecord.class);
-        Mockito.verify(producer, times(2)).write(recordCaptor.capture(), any());
+        Mockito.verify(producer, times(3)).write(recordCaptor.capture(), any());
 
         // verify only the first two messages was sent
-        context.assertEquals(2, recordCaptor.getAllValues().size());
+        context.assertEquals(3, recordCaptor.getAllValues().size());
         context.assertEquals(records.get(0), recordCaptor.getAllValues().get(0));
         context.assertEquals(records.get(1), recordCaptor.getAllValues().get(1));
+        context.assertEquals(records.get(2), recordCaptor.getAllValues().get(2));
     }
 
     private JsonObject buildSingleRecordPayload(String key){


### PR DESCRIPTION
Instead of waiting for each entry to return a.k.a forcing a sequential flow, we send all messages and let `org.apache.kafka` handle batching with the properties `batch.size` and `linger.ms` by enforcing parallel composition.