### PR TITLE
Added a new logger to keep track on HttpClient.close()

### DIFF
--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
@@ -33,8 +33,9 @@ public class Route {
     private static final boolean CLIENT_DEFAULT_EXPAND_IN_STORAGE = false;
     private static final int CLIENT_DEFAULT_LOG_EXPIRY = 4 * 3600;
 
-    private static Pattern URL_PARSE_PATTERN = Pattern.compile("^(?<scheme>https?)://(?<host>[^/:]+)(:(?<port>[0-9]+))?(?<path>/.*)$");
-    private static Logger LOG = LoggerFactory.getLogger(Route.class);
+    private static final Pattern URL_PARSE_PATTERN = Pattern.compile("^(?<scheme>https?)://(?<host>[^/:]+)(:(?<port>[0-9]+))?(?<path>/.*)$");
+    private static final Logger LOG = LoggerFactory.getLogger(Route.class);
+    private static final Logger CLEANUP_LOGGER = LoggerFactory.getLogger(Route.class.getName() + "Cleanup");
 
     private Vertx vertx;
     private LoggingResourceManager loggingResourceManager;
@@ -216,7 +217,7 @@ public class Route {
     public void cleanup() {
         if ( ! rule.getScheme().equals("local") ) {
             vertx.setTimer(GRACE_PERIOD, event -> {
-                LOG.debug("Cleaning up one client for route of " + urlPattern);
+                CLEANUP_LOGGER.debug("Cleaning up one client for route of " + urlPattern);
                 client.close();
             });
         }

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Router.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Router.java
@@ -49,6 +49,7 @@ public class Router implements Refreshable, LoggableResource, ConfigurationResou
     private final LoggingResourceManager loggingResourceManager;
     private final MonitoringHandler monitoringHandler;
     private final Logger log = LoggerFactory.getLogger(Router.class);
+    private final Logger cleanupLogger = LoggerFactory.getLogger(Router.class.getName() + "Cleanup");
     private final Vertx vertx;
     private final Set<HttpClient> httpClients = new HashSet<>();
     private final HttpClient selfClient;
@@ -337,7 +338,7 @@ public class Router implements Refreshable, LoggableResource, ConfigurationResou
         final HashSet<HttpClient> clientsToClose = new HashSet<>(httpClients);
         vertx.setTimer(GRACE_PERIOD, event -> {
             if (clientsToClose.size() > 0) {
-                log.debug("Cleaning up {} clients", clientsToClose.size());
+                cleanupLogger.debug("Cleaning up {} clients", clientsToClose.size());
             }
             for (HttpClient client : clientsToClose) {
                 client.close();


### PR DESCRIPTION
We occasionally see 

java.io.IOException: Stream closed

in our project and would like to track down if this is related to cleanup done within Gateleen. With this PR we introduce a dedicated logger to log cleanup related activity.