### PR TITLE
Fix suddenly broken routing rules for Playground

### DIFF
--- a/gateleen-playground/src/main/resources/playground/server/admin/v1/routing/rules
+++ b/gateleen-playground/src/main/resources/playground/server/admin/v1/routing/rules
@@ -25,7 +25,7 @@
     "path": "/playground/server/pages/index.html",
     "storage": "main"
   },
-  "/playground/([^/]*\\\\.html)": {
+  "/playground/([^/]*\\\\\\\\.html)": {
     "description": "Pages",
     "path": "/playground/server/pages/$1",
     "storage": "main"


### PR DESCRIPTION
Just stumbled over this one while working on another issue. Honestly I've no idea why I suddenly needed this patch locally.

On my machine the "steps-to-reproduce" results in a gateleen logging exceptions about that he cannot parse routing rules and the ui just displays "*Routing is broken*". By thinkering around I found that this fix here (see this PR) solved the issue for me.

Could someone please confirm this issue? Eg by reproducing it on another machine (see "steps to reproduce" further below). Anyone an idea why I need this patch locally?

The exceptions were somewhat like:
```
2021-07-06 21:19:00,698 gateleen ERROR RuleProvider - Could parse routing rules
ValidationException: Unable to parse json
        at org.swisspush.gateleen.routing.RuleFactory.parseRules(RuleFactory.java:46)
        at org.swisspush.gateleen.routing.RuleProvider.lambda$getRules$1(RuleProvider.java:75)
        at org.swisspush.gateleen.core.storage.EventBusResourceStorage$1.handle(EventBusResourceStorage.java:46)
        at org.swisspush.gateleen.core.storage.EventBusResourceStorage$1.handle(EventBusResourceStorage.java:34)
        at io.vertx.core.eventbus.impl.EventBusImpl.lambda$convertHandler$3(EventBusImpl.java:348)
        at io.vertx.core.eventbus.impl.HandlerRegistration.deliver(HandlerRegistration.java:261)
        at io.vertx.core.eventbus.impl.HandlerRegistration.handle(HandlerRegistration.java:239)
        at io.vertx.core.eventbus.impl.EventBusImpl$InboundDeliveryContext.next(EventBusImpl.java:565)
        at io.vertx.core.eventbus.impl.EventBusImpl.lambda$deliverToHandler$5(EventBusImpl.java:524)
        at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:320)
        at io.vertx.core.impl.EventLoopContext.lambda$executeAsync$0(EventLoopContext.java:38)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:462)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Thread.java:748)
```

Or also:
```
2021-07-06 21:19:00,722 gateleen INFO Router - Applying rules
2021-07-06 21:19:00,722 gateleen ERROR Router - Could not reconfigure routing
ValidationException: Unable to parse json
        at org.swisspush.gateleen.routing.RuleFactory.parseRules(RuleFactory.java:46)
        at org.swisspush.gateleen.routing.Router.updateRouting(Router.java:354)
        at org.swisspush.gateleen.routing.Router.lambda$new$0(Router.java:137)
        at org.swisspush.gateleen.core.storage.EventBusResourceStorage$1.handle(EventBusResourceStorage.java:46)
        at org.swisspush.gateleen.core.storage.EventBusResourceStorage$1.handle(EventBusResourceStorage.java:34)
        at io.vertx.core.eventbus.impl.EventBusImpl.lambda$convertHandler$3(EventBusImpl.java:348)
        at io.vertx.core.eventbus.impl.HandlerRegistration.deliver(HandlerRegistration.java:261)
        at io.vertx.core.eventbus.impl.HandlerRegistration.handle(HandlerRegistration.java:239)
        at io.vertx.core.eventbus.impl.EventBusImpl$InboundDeliveryContext.next(EventBusImpl.java:565)
        at io.vertx.core.eventbus.impl.EventBusImpl.lambda$deliverToHandler$5(EventBusImpl.java:524)
        at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:320)
        at io.vertx.core.impl.EventLoopContext.lambda$executeAsync$0(EventLoopContext.java:38)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:462)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Thread.java:748)
```

**Steps to reproduce**

Clone the repo (if not already done):
`git clone https://github.com/swisspush/gateleen.git`

Checkout the develop branch (I'll use an exact commit here to be more accurate):
`git co 82c2eb586ed41cad10d84ff80d77fdcb91501815`

Run a build (Maybe tests work for you. They never did for me for years. So as they fail anyway, they're useless to me):
`mvn clean install -DskipTests`

Stop gateleen (if you started one anywhere).

Make sure your --> **redis storage is empty**! <-- (For example by deleting the appendonly file)

Start gateleen-playground:
`java -jar gateleen-playground/target/playground.jar`

Do an upload of the resources (as our redis MUST be emptied beforehand. See above):
`mvn deploy -PuploadStaticFiles`

Restart the gateleen playground server. By doing this, I get the above mentioned behavior.