### PR TITLE
access control allow method PATCH for CORS

### DIFF
--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/cors/CORSHandler.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/cors/CORSHandler.java
@@ -44,7 +44,7 @@ public class CORSHandler {
         if (addCORSheaders && originHeader != null) {
             request.response().headers().set("Access-Control-Allow-Origin", originHeader);
             request.response().headers().set("Access-Control-Allow-Credentials", "true");
-            request.response().headers().set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, PUT, DELETE");
+            request.response().headers().set("Access-Control-Allow-Methods", "GET, PATCH, POST, OPTIONS, PUT, DELETE");
             if (HttpMethod.OPTIONS == request.method()) {
                 request.response().headers().set("Access-Control-Allow-Headers", request.headers().get("Access-Control-Request-Headers"));
             }

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/core/cors/CORSTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/core/cors/CORSTest.java
@@ -52,7 +52,7 @@ public class CORSTest extends AbstractTest {
                 .body("foo", equalTo("bar"))
                 .header("Access-Control-Allow-Origin", is("http://127.0.0.1:8888"))
                 .header("Access-Control-Allow-Credentials", is("true"))
-                .header("Access-Control-Allow-Methods", is("GET, POST, OPTIONS, PUT, DELETE"));
+                .header("Access-Control-Allow-Methods", is("GET, PATCH, POST, OPTIONS, PUT, DELETE"));
         async.complete();
     }
 
@@ -78,7 +78,7 @@ public class CORSTest extends AbstractTest {
                 .body("foo", equalTo("bar"))
                 .header("Access-Control-Allow-Origin", is("http://127.0.0.1:8888"))
                 .header("Access-Control-Allow-Credentials", is("true"))
-                .header("Access-Control-Allow-Methods", is("GET, POST, OPTIONS, PUT, DELETE"));
+                .header("Access-Control-Allow-Methods", is("GET, PATCH, POST, OPTIONS, PUT, DELETE"));
 
         async.complete();
     }


### PR DESCRIPTION
In our project we also use the PATCH method for cross-domain calls.
