### PR TITLE
support to configure maxWaitQueueSize on routes

### DIFF
--- a/gateleen-hook/README_hook.md
+++ b/gateleen-hook/README_hook.md
@@ -31,7 +31,7 @@ Adding hooks requires a validation against a schema to be positive. Check the sc
 | listable           | no  | This property specifies if a route is listed if a GET is performed on its parent or not. The default is false or set by the value passed during the initialization. | 
 | translateStatus    | no  | This property defines a mapping to translate http respond status values. | 
 | connectionPoolSize | no  | This property defines the max number of TCP connections which will be open in parallel to the destination system (Default 50) | 
-| maxWaitQueueSize   | no  | This property defines the max number of requests allowed in the wait queue. (Default -1, unbounded) | 
+| maxWaitQueueSize   | no  | This property defines the max number of requests allowed in the wait queue of the connection pool to the destination. If set to 0 then new incoming requests are rejected immediately if the pool is full (max connectionPoolSize reached), otherwise the requests are queued until the maxWaitQueueSize is reached and dispatched once connections in the pool become available. (Default -1, unbounded) | 
 
 > <font color="orange"><b>Attention:</b> </font>A route has a default expiration time of **1 hour**. After this time the route will expire and be removed from the storage, as well as the HookHandler.<br />
 To update / refresh a route, simply perform another registration.<br />

--- a/gateleen-hook/README_hook.md
+++ b/gateleen-hook/README_hook.md
@@ -31,6 +31,7 @@ Adding hooks requires a validation against a schema to be positive. Check the sc
 | listable           | no  | This property specifies if a route is listed if a GET is performed on its parent or not. The default is false or set by the value passed during the initialization. | 
 | translateStatus    | no  | This property defines a mapping to translate http respond status values. | 
 | connectionPoolSize | no  | This property defines the max number of TCP connections which will be open in parallel to the destination system (Default 50) | 
+| maxWaitQueueSize   | no  | This property defines the max number of requests allowed in the wait queue. (Default -1, unbounded) | 
 
 > <font color="orange"><b>Attention:</b> </font>A route has a default expiration time of **1 hour**. After this time the route will expire and be removed from the storage, as well as the HookHandler.<br />
 To update / refresh a route, simply perform another registration.<br />

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -1468,6 +1468,8 @@ public class HookHandler implements LoggableResource {
         // Configure connection pool size
         hook.setConnectionPoolSize(jsonHook.getInteger(HttpHook.CONNECTION_POOL_SIZE_PROPERTY_NAME));
 
+        hook.setMaxWaitQueueSize(jsonHook.getInteger(HttpHook.CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME));
+
         boolean mustCreateNewRoute = true;
         Route existingRoute = routeRepository.getRoutes().get(routedUrl);
         if (existingRoute != null) {
@@ -1502,6 +1504,7 @@ public class HookHandler implements LoggableResource {
         same &=                oldHook.isCollection         () ==     newHook.isCollection         () ;
         same &=                oldHook.isCollection         () ==     newHook.isCollection         () ;
         same &= Objects.equals(oldHook.getConnectionPoolSize() ,      newHook.getConnectionPoolSize());
+        same &= Objects.equals(oldHook.getMaxWaitQueueSize() ,        newHook.getMaxWaitQueueSize());
 
         // queueingStrategy, filter, queueExpireAfter and hookTriggerType are not relevant for Route-Hooks
         // Though, headerFunction WOULD BE relevant - but we can't compare them for equality

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HttpHook.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HttpHook.java
@@ -18,7 +18,9 @@ import java.util.regex.Pattern;
  */
 public class HttpHook {
     public static final String CONNECTION_POOL_SIZE_PROPERTY_NAME = Rule.CONNECTION_POOL_SIZE_PROPERTY_NAME;
+    public static final String CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME = Rule.CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME;
     public static final int CONNECTION_POOL_SIZE_DEFAULT_VALUE = Rule.CONNECTION_POOL_SIZE_DEFAULT_VALUE;
+    public static final int CONNECTION_MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE = Rule.CONNECTION_MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE;
     private String destination;
     private List<String> methods;
     private Map<Pattern, Integer> translateStatus;
@@ -32,6 +34,7 @@ public class HttpHook {
     private boolean listable = false;
     private boolean collection = true;
     private Integer connectionPoolSize = null;
+    private Integer maxWaitQueueSize = null;
     private ProxyOptions proxyOptions = null;
 
     /**
@@ -269,6 +272,25 @@ public class HttpHook {
             throw new IllegalArgumentException("Values below 1 not valid.");
         }
         this.connectionPoolSize = connectionPoolSize;
+    }
+
+    /**
+     * @return Max count of connections made to configured destination. This may
+     *      returning null in case there's no value specified. Callers may catch
+     *      that by fall back to a default.
+     */
+    public Integer getMaxWaitQueueSize() {
+        return maxWaitQueueSize;
+    }
+
+    /**
+     * See {@link #getMaxWaitQueueSize()}.
+     */
+    public void setMaxWaitQueueSize(Integer maxWaitQueueSize) {
+        if (maxWaitQueueSize != null && maxWaitQueueSize < -1){
+            throw new IllegalArgumentException("Values below -1 not valid.");
+        }
+        this.maxWaitQueueSize = maxWaitQueueSize;
     }
 
     /**

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HttpHook.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HttpHook.java
@@ -18,9 +18,9 @@ import java.util.regex.Pattern;
  */
 public class HttpHook {
     public static final String CONNECTION_POOL_SIZE_PROPERTY_NAME = Rule.CONNECTION_POOL_SIZE_PROPERTY_NAME;
-    public static final String CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME = Rule.CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME;
+    public static final String CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME = Rule.MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME;
     public static final int CONNECTION_POOL_SIZE_DEFAULT_VALUE = Rule.CONNECTION_POOL_SIZE_DEFAULT_VALUE;
-    public static final int CONNECTION_MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE = Rule.CONNECTION_MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE;
+    public static final int CONNECTION_MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE = Rule.MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE;
     private String destination;
     private List<String> methods;
     private Map<Pattern, Integer> translateStatus;
@@ -275,7 +275,7 @@ public class HttpHook {
     }
 
     /**
-     * @return Max count of connections made to configured destination. This may
+     * @return Maximum number of requests allowed in the wait queue. This may
      *      returning null in case there's no value specified. Callers may catch
      *      that by fall back to a default.
      */

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
@@ -115,6 +115,17 @@ public class Route {
             }
         }
 
+        { // Evaluate connection wait queue size
+            Integer maxWaitQueueSize = httpHook.getMaxWaitQueueSize();
+            if (maxWaitQueueSize == null) {
+                LOG.trace("No maxWaitQueueSize specified for route '{}' using default of {}.", rule.getRuleIdentifier(), HttpHook.CONNECTION_MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE);
+                rule.setMaxWaitQueueSize(HttpHook.CONNECTION_MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE);
+            } else {
+                LOG.trace("Using maxWaitQueueSize {} for route '{}'.", maxWaitQueueSize, rule.getRuleIdentifier());
+                rule.setMaxWaitQueueSize(maxWaitQueueSize);
+            }
+        }
+
         if (!httpHook.getMethods().isEmpty()) {
             rule.setMethods(httpHook.getMethods().toArray(new String[httpHook.getMethods().size()]));
         }

--- a/gateleen-hook/src/main/resources/gateleen_hooking_schema_hook
+++ b/gateleen-hook/src/main/resources/gateleen_hooking_schema_hook
@@ -85,6 +85,11 @@
 			"type": "integer",
 			"default": 50
 		},
+		"maxWaitQueueSize": {
+        	"description": "The maximum number of connections wait in the queue.",
+        	"type": "integer",
+        	"default": -1
+        },
 		"collection": {
 			"description": "only used for route hook",
 			"type": "boolean"

--- a/gateleen-hook/src/main/resources/gateleen_hooking_schema_hook
+++ b/gateleen-hook/src/main/resources/gateleen_hooking_schema_hook
@@ -86,7 +86,7 @@
 			"default": 50
 		},
 		"maxWaitQueueSize": {
-        	"description": "The maximum number of connections wait in the queue.",
+        	"description": "The maximum number of requests allowed in the wait queue.",
         	"type": "integer",
         	"default": -1
         },

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Rule.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Rule.java
@@ -12,7 +12,9 @@ import java.util.regex.Pattern;
 
 public class Rule {
     public static final String CONNECTION_POOL_SIZE_PROPERTY_NAME = "connectionPoolSize";
+    public static final String CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME = "maxWaitQueueSize";
     public static final int CONNECTION_POOL_SIZE_DEFAULT_VALUE = 50;
+    public static final int CONNECTION_MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE = -1;
     private String scheme;
     private String host;
     private String metricName;
@@ -20,6 +22,7 @@ public class Rule {
     private String portWildcard;
     private String path;
     private int poolSize;
+    private int maxWaitQueueSize;
     private boolean keepAlive;
     private boolean expandOnBackend;
     private boolean storageExpand;
@@ -101,6 +104,14 @@ public class Rule {
 
     public void setPoolSize(int poolSize) {
         this.poolSize = poolSize;
+    }
+
+    public int getMaxWaitQueueSize() {
+        return maxWaitQueueSize;
+    }
+
+    public void setMaxWaitQueueSize(int maxWaitQueueSize) {
+        this.maxWaitQueueSize = maxWaitQueueSize;
     }
 
     public boolean isKeepAlive() {
@@ -217,6 +228,7 @@ public class Rule {
                 .setConnectTimeout(getTimeout ())
                 .setKeepAlive     (isKeepAlive())
                 .setPipelining    (false        )
+                .setMaxWaitQueueSize(getMaxWaitQueueSize())
         ;
         if ("https".equals(getScheme())) {
             options.setSsl(true).setVerifyHost(false).setTrustAll(true);

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Rule.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Rule.java
@@ -12,9 +12,9 @@ import java.util.regex.Pattern;
 
 public class Rule {
     public static final String CONNECTION_POOL_SIZE_PROPERTY_NAME = "connectionPoolSize";
-    public static final String CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME = "maxWaitQueueSize";
+    public static final String MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME = "maxWaitQueueSize";
     public static final int CONNECTION_POOL_SIZE_DEFAULT_VALUE = 50;
-    public static final int CONNECTION_MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE = -1;
+    public static final int MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE = -1;
     private String scheme;
     private String host;
     private String metricName;

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RuleFactory.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RuleFactory.java
@@ -81,7 +81,7 @@ public class RuleFactory {
             int defaultTimeoutSec = 30;
             ruleObj.setTimeout(1000 * rule.getInteger("timeout", defaultTimeoutSec));
             ruleObj.setPoolSize(rule.getInteger(Rule.CONNECTION_POOL_SIZE_PROPERTY_NAME, Rule.CONNECTION_POOL_SIZE_DEFAULT_VALUE));
-            ruleObj.setMaxWaitQueueSize(rule.getInteger(Rule.CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME, Rule.CONNECTION_MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE));
+            ruleObj.setMaxWaitQueueSize(rule.getInteger(Rule.MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME, Rule.MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE));
             ruleObj.setKeepAlive(rule.getBoolean("keepAlive", true));
             ruleObj.setExpandOnBackend(rule.getBoolean("expandOnBackend", false));
             ruleObj.setStorageExpand(rule.getBoolean("storageExpand", false));

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RuleFactory.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RuleFactory.java
@@ -81,6 +81,7 @@ public class RuleFactory {
             int defaultTimeoutSec = 30;
             ruleObj.setTimeout(1000 * rule.getInteger("timeout", defaultTimeoutSec));
             ruleObj.setPoolSize(rule.getInteger(Rule.CONNECTION_POOL_SIZE_PROPERTY_NAME, Rule.CONNECTION_POOL_SIZE_DEFAULT_VALUE));
+            ruleObj.setMaxWaitQueueSize(rule.getInteger(Rule.CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME, Rule.CONNECTION_MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE));
             ruleObj.setKeepAlive(rule.getBoolean("keepAlive", true));
             ruleObj.setExpandOnBackend(rule.getBoolean("expandOnBackend", false));
             ruleObj.setStorageExpand(rule.getBoolean("storageExpand", false));

--- a/gateleen-routing/src/main/resources/gateleen_routing_schema_routing_rules
+++ b/gateleen-routing/src/main/resources/gateleen_routing_schema_routing_rules
@@ -63,7 +63,7 @@
 					"default": 50
 				},
 				"maxWaitQueueSize": {
-                	"description": "The maximum number of connections wait in the queue.",
+                	"description": "The maximum number of requests allowed in the wait queue.",
                 	"type": "integer",
                 	"default": -1
                 },

--- a/gateleen-routing/src/main/resources/gateleen_routing_schema_routing_rules
+++ b/gateleen-routing/src/main/resources/gateleen_routing_schema_routing_rules
@@ -62,6 +62,11 @@
 					"type": "integer",
 					"default": 50
 				},
+				"maxWaitQueueSize": {
+                	"description": "The maximum number of connections wait in the queue.",
+                	"type": "integer",
+                	"default": -1
+                },
 				"keepAlive": {
 					"description": "Keeps the connection to the backend open.\nThis may improve performance but degrades the reliability in case of failure, requests can be lost.\nHas no effect for local/storage forwarding.",
 					"default": false,


### PR DESCRIPTION
Currently incoming requests get queued up once the connection pool is full. There is no size limit for this queue so far. With this PR we make it configurable. The default will be "unbounded", this means that everything stays the same if not actually configured.