### PR TITLE
Revert "#394 Preserve Host header value if it exists"

### DIFF
--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
@@ -1,7 +1,6 @@
 package org.swisspush.gateleen.core.util;
 
 import io.vertx.core.MultiMap;
-import java.util.Map.Entry;
 
 
 public class HttpHeaderUtil {
@@ -29,28 +28,6 @@ public class HttpHeaderUtil {
         headers.remove(CONNECTION);
 
         return headers;
-    }
-
-    /**
-     * Helper method to find the first occurrence of a http header within the given List of headers.
-     *
-     * @param headers   The Map with the header key - value pairs to be evaluated
-     * @param headerKey The key for the header pair we are searching for in the given map. Note that
-     *                  the key searching is non case sensitive.
-     * @return The found header value or null if none found
-     */
-    public static <T extends MultiMap> String getHeaderValue(T headers, String headerKey) {
-        String matchKey = headerKey.toLowerCase();
-        for (Entry<String, String> entry : headers.entries()) {
-            if (entry.getKey().toLowerCase().equals(matchKey)) {
-                String value = entry.getValue();
-                if (value != null) {
-                    return value.trim();
-                }
-                return null;
-            }
-        }
-        return null;
     }
 
 }

--- a/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/HttpHeaderUtilTest.java
+++ b/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/HttpHeaderUtilTest.java
@@ -41,25 +41,4 @@ public class HttpHeaderUtilTest {
         testContext.assertEquals(2, headers.size());
     }
 
-    @Test
-    public void getHeaderValueTest(TestContext testContext) {
-
-        // Mock an example header
-        CaseInsensitiveHeaders headers = new CaseInsensitiveHeaders();
-        headers.add("dummy-header", "123");
-        headers.add("even-more-dummy-header", "anyvalue");
-        headers.add("host", "host:1234");
-
-        String value = HttpHeaderUtil.getHeaderValue(headers, "Host");
-        // Assert correct returned value found even with unequal case
-        testContext.assertEquals(value,"host:1234");
-
-        value = HttpHeaderUtil.getHeaderValue(headers, "someHeader");
-        // Assert not found
-        testContext.assertNull(value);
-
-    }
-
-
-
 }

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
@@ -6,34 +6,27 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpConnection;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.*;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.streams.Pump;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.ext.web.RoutingContext;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeoutException;
-import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.swisspush.gateleen.core.http.HeaderFunctions;
 import org.swisspush.gateleen.core.http.RequestLoggerFactory;
 import org.swisspush.gateleen.core.storage.ResourceStorage;
-import org.swisspush.gateleen.core.util.HttpHeaderUtil;
-import org.swisspush.gateleen.core.util.ResponseStatusCodeLogUtil;
-import org.swisspush.gateleen.core.util.StatusCode;
-import org.swisspush.gateleen.core.util.StringUtils;
+import org.swisspush.gateleen.core.util.*;
 import org.swisspush.gateleen.logging.LoggingHandler;
 import org.swisspush.gateleen.logging.LoggingResourceManager;
 import org.swisspush.gateleen.logging.LoggingWriteStream;
 import org.swisspush.gateleen.monitoring.MonitoringHandler;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 
 /**
  * Forwards requests to the backend.
@@ -169,7 +162,7 @@ public class Forwarder implements Handler<RoutingContext> {
 
     /**
      * Returns the userId defined in the on-behalf-of-header if provided, the userId from user-header otherwise.
-     *
+     * 
      * @param request request
      * @param log log
      */
@@ -211,26 +204,16 @@ public class Forwarder implements Handler<RoutingContext> {
             cReq.headers().set("x-rp-unique-id", uniqueId);
         }
         setProfileHeaders(log, profileHeaderMap, cReq);
-
+        // https://jira/browse/NEMO-1494
+        // the Host has to be set, if only added it will add a second value and not overwrite existing ones
+        cReq.headers().set("Host", target.split("/")[0]);
         if (base64UsernamePassword != null) {
             cReq.headers().set("Authorization", "Basic " + base64UsernamePassword);
         }
 
-        // apply the configured rules headers to the request headers
+
         MultiMap headers = cReq.headers();
         final HeaderFunctions.EvalScope evalScope = rule.getHeaderFunction().apply(headers);
-
-        // check if we have already a Host header in the request
-        // either given from the caller or a previously applied rule
-        // don't overwrite the Host header if there is already one
-        // https://github.com/swisspush/gateleen/issues/394
-        String hostHeader = HttpHeaderUtil.getHeaderValue(headers, "Host");
-        if (hostHeader == null) {
-            // https://jira.post.ch/browse/NEMO-1494
-            // the Host has to be set, if only added it will add a second value and not overwrite existing ones
-            headers.set("Host", target.split("/")[0]);
-        }
-
         if (evalScope.getErrorMessage() != null) {
             log.warn("Problem invoking Header functions: {}", evalScope.getErrorMessage());
             final HttpServerResponse response = req.response();


### PR DESCRIPTION
This reverts commit 8a00cbad, this is due to side effects seen: 

We have now cases where the host header doesn't match with the host in the URL (it actually carries the value "localhost"), this leads to rejection with a 503 on the receiving end (in this case an open shift platform).