### PR TITLE
#394 Improvement for Host header handling

### DIFF
--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
@@ -42,9 +42,8 @@ public class HttpHeaderUtil {
      * @return The found header value or null if none found
      */
     public @Nullable static <T extends MultiMap> String getHeaderValue(@Nonnull T headers, @Nonnull String headerKey) {
-        String matchKey = headerKey.toLowerCase();
         for (Entry<String, String> entry : headers.entries()) {
-            if (entry.getKey().equalsIgnoreCase(matchKey)) {
+            if (entry.getKey().equalsIgnoreCase(headerKey)) {
                 String value = entry.getValue();
                 if (value != null) {
                     return value.trim();

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
@@ -2,6 +2,8 @@ package org.swisspush.gateleen.core.util;
 
 import io.vertx.core.MultiMap;
 import java.util.Map.Entry;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 
 public class HttpHeaderUtil {
@@ -39,10 +41,10 @@ public class HttpHeaderUtil {
      *                  the key searching is non case sensitive.
      * @return The found header value or null if none found
      */
-    public static <T extends MultiMap> String getHeaderValue(T headers, String headerKey) {
+    public @Nullable static <T extends MultiMap> String getHeaderValue(@Nonnull T headers, @Nonnull String headerKey) {
         String matchKey = headerKey.toLowerCase();
         for (Entry<String, String> entry : headers.entries()) {
-            if (entry.getKey().toLowerCase().equals(matchKey)) {
+            if (entry.getKey().equalsIgnoreCase(matchKey)) {
                 String value = entry.getValue();
                 if (value != null) {
                     return value.trim();

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
@@ -1,6 +1,7 @@
 package org.swisspush.gateleen.core.util;
 
 import io.vertx.core.MultiMap;
+import java.util.Map.Entry;
 
 
 public class HttpHeaderUtil {
@@ -28,6 +29,28 @@ public class HttpHeaderUtil {
         headers.remove(CONNECTION);
 
         return headers;
+    }
+
+    /**
+     * Helper method to find the first occurrence of a http header within the given List of headers.
+     *
+     * @param headers   The Map with the header key - value pairs to be evaluated
+     * @param headerKey The key for the header pair we are searching for in the given map. Note that
+     *                  the key searching is non case sensitive.
+     * @return The found header value or null if none found
+     */
+    public static <T extends MultiMap> String getHeaderValue(T headers, String headerKey) {
+        String matchKey = headerKey.toLowerCase();
+        for (Entry<String, String> entry : headers.entries()) {
+            if (entry.getKey().toLowerCase().equals(matchKey)) {
+                String value = entry.getValue();
+                if (value != null) {
+                    return value.trim();
+                }
+                return null;
+            }
+        }
+        return null;
     }
 
 }

--- a/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/HttpHeaderUtilTest.java
+++ b/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/HttpHeaderUtilTest.java
@@ -41,4 +41,25 @@ public class HttpHeaderUtilTest {
         testContext.assertEquals(2, headers.size());
     }
 
+    @Test
+    public void getHeaderValueTest(TestContext testContext) {
+
+        // Mock an example header
+        CaseInsensitiveHeaders headers = new CaseInsensitiveHeaders();
+        headers.add("dummy-header", "123");
+        headers.add("even-more-dummy-header", "anyvalue");
+        headers.add("host", "host:1234");
+
+        String value = HttpHeaderUtil.getHeaderValue(headers, "Host");
+        // Assert correct returned value found even with unequal case
+        testContext.assertEquals(value,"host:1234");
+
+        value = HttpHeaderUtil.getHeaderValue(headers, "someHeader");
+        // Assert not found
+        testContext.assertNull(value);
+
+    }
+
+
+
 }

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
@@ -212,25 +212,21 @@ public class Forwarder implements Handler<RoutingContext> {
             cReq.headers().set("Authorization", "Basic " + base64UsernamePassword);
         }
 
-
         MultiMap headers = cReq.headers();
-        String hostHeaderBefore = HttpHeaderUtil.getHeaderValue(headers, HOST_HEADER);
+        final String hostHeaderBefore = HttpHeaderUtil.getHeaderValue(headers, HOST_HEADER);
         final HeaderFunctions.EvalScope evalScope = rule.getHeaderFunction().apply(headers);
-        String hostHeaderAfter = HttpHeaderUtil.getHeaderValue(headers, HOST_HEADER);
+        final String hostHeaderAfter = HttpHeaderUtil.getHeaderValue(headers, HOST_HEADER);
         // see https://github.com/swisspush/gateleen/issues/394
-        if (hostHeaderAfter == null ||
-            (hostHeaderAfter != null && hostHeaderAfter.equals(hostHeaderBefore))) {
-            // there was no host header before or the host header was not updated by the rule given, therefore
-            // the host header will be forced overwritten always independent of the incoming value.
-            // This allows us to configure for certain routings to external url a dedicated Host header
-            // which will not be overwritten.
-            //
-            // https://jira.post.ch/browse/NEMO-1494
-            // the Host has to be set, if only added it will add a second value and not overwrite existing ones
-            String newHost = target.split("/")[0];
+        if (hostHeaderAfter == null || hostHeaderAfter.equals(hostHeaderBefore)) {
+            // there was no host header before or the host header was not updated by the rule given,
+            // therefore it will be forced overwritten always independent of the incoming value.
+            final String newHost = target.split("/")[0];
             headers.set(HOST_HEADER, newHost);
             log.debug("Host header replaced by default target value: {}", newHost);
         } else {
+            // the host header was changed by the configured routing and therefore
+            // it is not updated. This allows us to configure for certain routings to external
+            // url a dedicated Host header which will not be overwritten.
             log.debug("Host header replaced by rule value: {}", hostHeaderAfter);
         }
 

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
@@ -6,27 +6,34 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.*;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.streams.Pump;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.ext.web.RoutingContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.swisspush.gateleen.core.http.HeaderFunctions;
-import org.swisspush.gateleen.core.http.RequestLoggerFactory;
-import org.swisspush.gateleen.core.storage.ResourceStorage;
-import org.swisspush.gateleen.core.util.*;
-import org.swisspush.gateleen.logging.LoggingHandler;
-import org.swisspush.gateleen.logging.LoggingResourceManager;
-import org.swisspush.gateleen.logging.LoggingWriteStream;
-import org.swisspush.gateleen.monitoring.MonitoringHandler;
-
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.swisspush.gateleen.core.http.HeaderFunctions;
+import org.swisspush.gateleen.core.http.RequestLoggerFactory;
+import org.swisspush.gateleen.core.storage.ResourceStorage;
+import org.swisspush.gateleen.core.util.HttpHeaderUtil;
+import org.swisspush.gateleen.core.util.ResponseStatusCodeLogUtil;
+import org.swisspush.gateleen.core.util.StatusCode;
+import org.swisspush.gateleen.core.util.StringUtils;
+import org.swisspush.gateleen.logging.LoggingHandler;
+import org.swisspush.gateleen.logging.LoggingResourceManager;
+import org.swisspush.gateleen.logging.LoggingWriteStream;
+import org.swisspush.gateleen.monitoring.MonitoringHandler;
 
 /**
  * Forwards requests to the backend.
@@ -162,7 +169,7 @@ public class Forwarder implements Handler<RoutingContext> {
 
     /**
      * Returns the userId defined in the on-behalf-of-header if provided, the userId from user-header otherwise.
-     * 
+     *
      * @param request request
      * @param log log
      */
@@ -204,16 +211,26 @@ public class Forwarder implements Handler<RoutingContext> {
             cReq.headers().set("x-rp-unique-id", uniqueId);
         }
         setProfileHeaders(log, profileHeaderMap, cReq);
-        // https://jira/browse/NEMO-1494
-        // the Host has to be set, if only added it will add a second value and not overwrite existing ones
-        cReq.headers().set("Host", target.split("/")[0]);
+
         if (base64UsernamePassword != null) {
             cReq.headers().set("Authorization", "Basic " + base64UsernamePassword);
         }
 
-
+        // apply the configured rules headers to the request headers
         MultiMap headers = cReq.headers();
         final HeaderFunctions.EvalScope evalScope = rule.getHeaderFunction().apply(headers);
+
+        // check if we have already a Host header in the request
+        // either given from the caller or a previously applied rule
+        // don't overwrite the Host header if there is already one
+        // https://github.com/swisspush/gateleen/issues/394
+        String hostHeader = HttpHeaderUtil.getHeaderValue(headers, "Host");
+        if (hostHeader == null) {
+            // https://jira.post.ch/browse/NEMO-1494
+            // the Host has to be set, if only added it will add a second value and not overwrite existing ones
+            headers.set("Host", target.split("/")[0]);
+        }
+
         if (evalScope.getErrorMessage() != null) {
             log.warn("Problem invoking Header functions: {}", evalScope.getErrorMessage());
             final HttpServerResponse response = req.response();

--- a/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/ForwarderTest.java
+++ b/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/ForwarderTest.java
@@ -7,7 +7,6 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,15 +32,15 @@ public class ForwarderTest {
   private LoggingResourceManager loggingResourceManager;
   private MonitoringHandler monitoringHandler;
   private HttpClient httpClient;
-  private String serverUrl;
-  private String rulesPath;
-  private String userProfilePath;
   private ResourceStorage storage;
   private Logger logger;
 
-  private final static String DEFAULTHOST = "DEFAULTHOST";
-  private final static int DEFAULTPORT = 1234;
+  private static final String DEFAULTHOST = "DEFAULTHOST";
+  private static final int DEFAULTPORT = 1234;
   private static final String HOST_HEADER = "Host";
+  private static final String SERVER_URL = "/gateleen/server";
+  private static final String RULES_PATH = SERVER_URL + "/admin/v1/routing/rules";
+  private static final String USER_PROFILE_PATH = SERVER_URL + "/users/v1/%s/profile";
 
   private static final String RULES = "{\n"
       + "  \"/ruleWithoutHeader\": {\n"
@@ -77,59 +76,56 @@ public class ForwarderTest {
     loggingResourceManager = Mockito.mock(LoggingResourceManager.class);
     monitoringHandler = Mockito.mock(MonitoringHandler.class);
     httpClient = Mockito.mock(HttpClient.class);
-    serverUrl = "/gateleen/server";
-    rulesPath = serverUrl + "/admin/v1/routing/rules";
-    userProfilePath = serverUrl + "/users/v1/%s/profile";
-    storage = new MockResourceStorage(ImmutableMap.of(rulesPath, RULES));
+    storage = new MockResourceStorage(ImmutableMap.of(RULES_PATH, RULES));
     logger = LoggerFactory.getLogger(ForwarderTest.class.getName());
   }
 
   @Test
-  public void testHeaderFunctionsWithHostHeader(TestContext context) {
+  public void testHeaderFunctionsWithHostHeader() {
     Rule rule = extractRule("/ruleWithHostHeader");
     Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
-        monitoringHandler, userProfilePath);
+        monitoringHandler, USER_PROFILE_PATH);
     MultiMap reqHeaders = new VertxHttpHeaders();
     reqHeaders.add(HOST_HEADER, "oldHost1234");
     String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
     Assert.assertNull(errorMessage);
-    Assert.assertTrue(reqHeaders.get(HOST_HEADER).equals("newHost"));
+    Assert.assertEquals(reqHeaders.get(HOST_HEADER),"newHost");
   }
 
   @Test
-  public void testHeaderFunctionsDefaultWithHostHeader(TestContext context) {
+  public void testHeaderFunctionsDefaultWithHostHeader() {
     Rule rule = extractRule("/ruleWithHostHeader");
     Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
-        monitoringHandler, userProfilePath);
+        monitoringHandler, USER_PROFILE_PATH);
     MultiMap reqHeaders = new VertxHttpHeaders();
     reqHeaders.add(HOST_HEADER, DEFAULTHOST + ":" + DEFAULTPORT);
     String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
     Assert.assertNull(errorMessage);
-    Assert.assertTrue(reqHeaders.get(HOST_HEADER).equals("newHost"));
+    Assert.assertEquals(reqHeaders.get(HOST_HEADER),"newHost");
   }
 
   @Test
-  public void testHeaderFunctionsWithoutHostHeader(TestContext context) {
+  public void testHeaderFunctionsWithoutHostHeader() {
     Rule rule = extractRule("/ruleWithoutHeader");
     Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
-        monitoringHandler, userProfilePath);
+        monitoringHandler, USER_PROFILE_PATH);
     MultiMap reqHeaders = new VertxHttpHeaders();
     reqHeaders.add(HOST_HEADER, "oldHost:1234");
     String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
     Assert.assertNull(errorMessage);
-    Assert.assertTrue(reqHeaders.get(HOST_HEADER).equals(DEFAULTHOST + ":" + DEFAULTPORT));
+    Assert.assertEquals(reqHeaders.get(HOST_HEADER),DEFAULTHOST + ":" + DEFAULTPORT);
   }
 
   @Test
-  public void testHeaderFunctionsDefaultWithoutHostHeader(TestContext context) {
+  public void testHeaderFunctionsDefaultWithoutHostHeader() {
     Rule rule = extractRule("/ruleWithoutHeader");
     Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
-        monitoringHandler, userProfilePath);
+        monitoringHandler, USER_PROFILE_PATH);
     MultiMap reqHeaders = new VertxHttpHeaders();
     reqHeaders.add(HOST_HEADER, DEFAULTHOST + ":" + DEFAULTPORT);
     String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
     Assert.assertNull(errorMessage);
-    Assert.assertTrue(reqHeaders.get(HOST_HEADER).equals(DEFAULTHOST + ":" + DEFAULTPORT));
+    Assert.assertEquals(reqHeaders.get(HOST_HEADER),DEFAULTHOST + ":" + DEFAULTPORT);
   }
 
 

--- a/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/ForwarderTest.java
+++ b/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/ForwarderTest.java
@@ -28,105 +28,127 @@ import org.swisspush.gateleen.monitoring.MonitoringHandler;
 @RunWith(VertxUnitRunner.class)
 public class ForwarderTest {
 
-  private Vertx vertx;
-  private LoggingResourceManager loggingResourceManager;
-  private MonitoringHandler monitoringHandler;
-  private HttpClient httpClient;
-  private ResourceStorage storage;
-  private Logger logger;
+    private Vertx vertx;
+    private LoggingResourceManager loggingResourceManager;
+    private MonitoringHandler monitoringHandler;
+    private HttpClient httpClient;
+    private ResourceStorage storage;
+    private Logger logger;
 
-  private static final String DEFAULTHOST = "DEFAULTHOST";
-  private static final int DEFAULTPORT = 1234;
-  private static final String HOST_HEADER = "Host";
-  private static final String SERVER_URL = "/gateleen/server";
-  private static final String RULES_PATH = SERVER_URL + "/admin/v1/routing/rules";
-  private static final String USER_PROFILE_PATH = SERVER_URL + "/users/v1/%s/profile";
+    private static final String DEFAULTHOST = "defaultHost";
+    private static final int DEFAULTPORT = 1234;
+    private static final String HOST_HEADER = "Host";
+    private static final String HOST_DEFAULT = DEFAULTHOST + ":" + DEFAULTPORT;
+    private static final String HOST_OLD = "oldHost:123";
+    private static final String HOST_NEW = "newHost:123";
+    private static final String SERVER_URL = "/gateleen/server";
+    private static final String RULES_PATH = SERVER_URL + "/admin/v1/routing/rules";
+    private static final String USER_PROFILE_PATH = SERVER_URL + "/users/v1/%s/profile";
 
-  private static final String RULES = "{\n"
-      + "  \"/ruleWithoutHeader\": {\n"
-      + "    \"description\": \"Test Rule 1\",\n"
-      + "    \"url\": \"/gateleen/rule/1\"\n"
-      + "  },\n"
-      + "  \"/ruleWithHostHeader\": {\n"
-      + "    \"description\": \"Test Rule 2\",\n"
-      + "    \"url\": \"/gateleen/rule/2\",\n"
-      + "    \"headers\": [{ \"header\": \"Host\" , \"value\": \"newHost\"}]"
-      + "  }\n"
-      + "}";
+    private static final String RULES = "{\n"
+            + "  \"/ruleWithoutHeader\": {\n"
+            + "    \"description\": \"Test Rule 1\",\n"
+            + "    \"url\": \"/gateleen/rule/1\"\n"
+            + "  },\n"
+            + "  \"/ruleWithHostHeader\": {\n"
+            + "    \"description\": \"Test Rule 2\",\n"
+            + "    \"url\": \"/gateleen/rule/2\",\n"
+            + "    \"headers\": [{ \"header\": \"" + HOST_HEADER + "\" , \"value\": \"" + HOST_NEW + "\"}]"
+            + "  }\n"
+            + "}";
 
-
-  private static Rule extractRule(String rulePattern) {
-    Rule rule = new Rule();
-    JsonObject rules = new JsonObject(RULES);
-    JsonObject extractedRule = rules.getJsonObject(rulePattern);
-    JsonArray headers = extractedRule.getJsonArray("headers");
-    if (headers != null) {
-      HeaderFunction headerFunction = HeaderFunctions.parseFromJson(headers);
-      rule.setHeaderFunction(headerFunction);
+    private static Rule extractRule(String rulePattern) {
+        Rule rule = new Rule();
+        JsonObject rules = new JsonObject(RULES);
+        JsonObject extractedRule = rules.getJsonObject(rulePattern);
+        JsonArray headers = extractedRule.getJsonArray("headers");
+        if (headers != null) {
+            HeaderFunction headerFunction = HeaderFunctions.parseFromJson(headers);
+            rule.setHeaderFunction(headerFunction);
+        }
+        rule.setUrlPattern(extractedRule.getString("url"));
+        rule.setHost(DEFAULTHOST);
+        rule.setPort(DEFAULTPORT);
+        return rule;
     }
-    rule.setUrlPattern(extractedRule.getString("url"));
-    rule.setHost(DEFAULTHOST);
-    rule.setPort(DEFAULTPORT);
-    return rule;
-  }
 
-  @Before
-  public void setUp() {
-    vertx = Mockito.mock(Vertx.class);
-    loggingResourceManager = Mockito.mock(LoggingResourceManager.class);
-    monitoringHandler = Mockito.mock(MonitoringHandler.class);
-    httpClient = Mockito.mock(HttpClient.class);
-    storage = new MockResourceStorage(ImmutableMap.of(RULES_PATH, RULES));
-    logger = LoggerFactory.getLogger(ForwarderTest.class.getName());
-  }
+    @Before
+    public void setUp() {
+        vertx = Mockito.mock(Vertx.class);
+        loggingResourceManager = Mockito.mock(LoggingResourceManager.class);
+        monitoringHandler = Mockito.mock(MonitoringHandler.class);
+        httpClient = Mockito.mock(HttpClient.class);
+        storage = new MockResourceStorage(ImmutableMap.of(RULES_PATH, RULES));
+        logger = LoggerFactory.getLogger(ForwarderTest.class);
+    }
 
-  @Test
-  public void testHeaderFunctionsWithHostHeader() {
-    Rule rule = extractRule("/ruleWithHostHeader");
-    Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
-        monitoringHandler, USER_PROFILE_PATH);
-    MultiMap reqHeaders = new VertxHttpHeaders();
-    reqHeaders.add(HOST_HEADER, "oldHost1234");
-    String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
-    Assert.assertNull(errorMessage);
-    Assert.assertEquals(reqHeaders.get(HOST_HEADER),"newHost");
-  }
+    @Test
+    public void testHeaderFunctionsGivenHostUpdatedByConfiguredRuleHostHeader() {
+        Rule rule = extractRule("/ruleWithHostHeader");
+        Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
+                monitoringHandler, USER_PROFILE_PATH);
+        MultiMap reqHeaders = new VertxHttpHeaders();
+        reqHeaders.add(HOST_HEADER, HOST_OLD);
+        String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
+        Assert.assertNull(errorMessage);
+        Assert.assertEquals(HOST_NEW, reqHeaders.get(HOST_HEADER));
+    }
 
-  @Test
-  public void testHeaderFunctionsDefaultWithHostHeader() {
-    Rule rule = extractRule("/ruleWithHostHeader");
-    Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
-        monitoringHandler, USER_PROFILE_PATH);
-    MultiMap reqHeaders = new VertxHttpHeaders();
-    reqHeaders.add(HOST_HEADER, DEFAULTHOST + ":" + DEFAULTPORT);
-    String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
-    Assert.assertNull(errorMessage);
-    Assert.assertEquals(reqHeaders.get(HOST_HEADER),"newHost");
-  }
+    @Test
+    public void testHeaderFunctionsDefaultHostHeaderUpdatedByConfiguredRuleHostHeader() {
+        Rule rule = extractRule("/ruleWithHostHeader");
+        Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
+                monitoringHandler, USER_PROFILE_PATH);
+        MultiMap reqHeaders = new VertxHttpHeaders();
+        reqHeaders.add(HOST_HEADER, HOST_DEFAULT);
+        String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
+        Assert.assertNull(errorMessage);
+        Assert.assertEquals(HOST_NEW, reqHeaders.get(HOST_HEADER));
+    }
 
-  @Test
-  public void testHeaderFunctionsWithoutHostHeader() {
-    Rule rule = extractRule("/ruleWithoutHeader");
-    Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
-        monitoringHandler, USER_PROFILE_PATH);
-    MultiMap reqHeaders = new VertxHttpHeaders();
-    reqHeaders.add(HOST_HEADER, "oldHost:1234");
-    String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
-    Assert.assertNull(errorMessage);
-    Assert.assertEquals(reqHeaders.get(HOST_HEADER),DEFAULTHOST + ":" + DEFAULTPORT);
-  }
+    /**
+     * This is a very special case which should not happen in reality with a proper rule configuration.
+     * As we do not want to care about the incoming header (from outside) we assume that it must be always
+     * the default host header coming in and therefore it will be reset to the default header anyway if it will not be
+     * the case.
+     *
+     * This could happen therefore only if the configured rule host header would match the default one and this
+     * would not make sense to be configured like that as it would result in the same as configuring no host header.
+     */
+    @Test
+    public void testHeaderFunctionsGivenHostHeaderUpdatedToDefaultHostHeaderWhenEqualToConfiguredRuleHostHeader() {
+        Rule rule = extractRule("/ruleWithHostHeader");
+        Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
+                monitoringHandler, USER_PROFILE_PATH);
+        MultiMap reqHeaders = new VertxHttpHeaders();
+        reqHeaders.add(HOST_HEADER, HOST_NEW);
+        String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
+        Assert.assertNull(errorMessage);
+        Assert.assertEquals(HOST_DEFAULT, reqHeaders.get(HOST_HEADER));
+    }
 
-  @Test
-  public void testHeaderFunctionsDefaultWithoutHostHeader() {
-    Rule rule = extractRule("/ruleWithoutHeader");
-    Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
-        monitoringHandler, USER_PROFILE_PATH);
-    MultiMap reqHeaders = new VertxHttpHeaders();
-    reqHeaders.add(HOST_HEADER, DEFAULTHOST + ":" + DEFAULTPORT);
-    String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
-    Assert.assertNull(errorMessage);
-    Assert.assertEquals(reqHeaders.get(HOST_HEADER),DEFAULTHOST + ":" + DEFAULTPORT);
-  }
+    @Test
+    public void testHeaderFunctionsGivenHostHeaderUpdatedByDefaultHostHeaderWhenNoConfiguredRuleHostHeader() {
+        Rule rule = extractRule("/ruleWithoutHeader");
+        Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
+                monitoringHandler, USER_PROFILE_PATH);
+        MultiMap reqHeaders = new VertxHttpHeaders();
+        reqHeaders.add(HOST_HEADER, HOST_OLD);
+        String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
+        Assert.assertNull(errorMessage);
+        Assert.assertEquals(HOST_DEFAULT, reqHeaders.get(HOST_HEADER));
+    }
 
+    @Test
+    public void testHeaderFunctionsGivenDefaultHostHeaderRemainsWhenNoConfiguredRuleHostHeader() {
+        Rule rule = extractRule("/ruleWithoutHeader");
+        Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
+                monitoringHandler, USER_PROFILE_PATH);
+        MultiMap reqHeaders = new VertxHttpHeaders();
+        reqHeaders.add(HOST_HEADER, HOST_DEFAULT);
+        String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
+        Assert.assertNull(errorMessage);
+        Assert.assertEquals(HOST_DEFAULT, reqHeaders.get(HOST_HEADER));
+    }
 
 }

--- a/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/ForwarderTest.java
+++ b/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/ForwarderTest.java
@@ -1,0 +1,136 @@
+package org.swisspush.gateleen.routing;
+
+import com.google.common.collect.ImmutableMap;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.swisspush.gateleen.core.http.HeaderFunction;
+import org.swisspush.gateleen.core.http.HeaderFunctions;
+import org.swisspush.gateleen.core.storage.MockResourceStorage;
+import org.swisspush.gateleen.core.storage.ResourceStorage;
+import org.swisspush.gateleen.logging.LoggingResourceManager;
+import org.swisspush.gateleen.monitoring.MonitoringHandler;
+
+/**
+ * Tests for the Forwarder class
+ */
+@RunWith(VertxUnitRunner.class)
+public class ForwarderTest {
+
+  private Vertx vertx;
+  private LoggingResourceManager loggingResourceManager;
+  private MonitoringHandler monitoringHandler;
+  private HttpClient httpClient;
+  private String serverUrl;
+  private String rulesPath;
+  private String userProfilePath;
+  private ResourceStorage storage;
+  private Logger logger;
+
+  private final static String DEFAULTHOST = "DEFAULTHOST";
+  private final static int DEFAULTPORT = 1234;
+  private static final String HOST_HEADER = "Host";
+
+  private static final String RULES = "{\n"
+      + "  \"/ruleWithoutHeader\": {\n"
+      + "    \"description\": \"Test Rule 1\",\n"
+      + "    \"url\": \"/gateleen/rule/1\"\n"
+      + "  },\n"
+      + "  \"/ruleWithHostHeader\": {\n"
+      + "    \"description\": \"Test Rule 2\",\n"
+      + "    \"url\": \"/gateleen/rule/2\",\n"
+      + "    \"headers\": [{ \"header\": \"Host\" , \"value\": \"newHost\"}]"
+      + "  }\n"
+      + "}";
+
+
+  private static Rule extractRule(String rulePattern) {
+    Rule rule = new Rule();
+    JsonObject rules = new JsonObject(RULES);
+    JsonObject extractedRule = rules.getJsonObject(rulePattern);
+    JsonArray headers = extractedRule.getJsonArray("headers");
+    if (headers != null) {
+      HeaderFunction headerFunction = HeaderFunctions.parseFromJson(headers);
+      rule.setHeaderFunction(headerFunction);
+    }
+    rule.setUrlPattern(extractedRule.getString("url"));
+    rule.setHost(DEFAULTHOST);
+    rule.setPort(DEFAULTPORT);
+    return rule;
+  }
+
+  @Before
+  public void setUp() {
+    vertx = Mockito.mock(Vertx.class);
+    loggingResourceManager = Mockito.mock(LoggingResourceManager.class);
+    monitoringHandler = Mockito.mock(MonitoringHandler.class);
+    httpClient = Mockito.mock(HttpClient.class);
+    serverUrl = "/gateleen/server";
+    rulesPath = serverUrl + "/admin/v1/routing/rules";
+    userProfilePath = serverUrl + "/users/v1/%s/profile";
+    storage = new MockResourceStorage(ImmutableMap.of(rulesPath, RULES));
+    logger = LoggerFactory.getLogger(ForwarderTest.class.getName());
+  }
+
+  @Test
+  public void testHeaderFunctionsWithHostHeader(TestContext context) {
+    Rule rule = extractRule("/ruleWithHostHeader");
+    Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
+        monitoringHandler, userProfilePath);
+    MultiMap reqHeaders = new VertxHttpHeaders();
+    reqHeaders.add(HOST_HEADER, "oldHost1234");
+    String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
+    Assert.assertNull(errorMessage);
+    Assert.assertTrue(reqHeaders.get(HOST_HEADER).equals("newHost"));
+  }
+
+  @Test
+  public void testHeaderFunctionsDefaultWithHostHeader(TestContext context) {
+    Rule rule = extractRule("/ruleWithHostHeader");
+    Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
+        monitoringHandler, userProfilePath);
+    MultiMap reqHeaders = new VertxHttpHeaders();
+    reqHeaders.add(HOST_HEADER, DEFAULTHOST + ":" + DEFAULTPORT);
+    String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
+    Assert.assertNull(errorMessage);
+    Assert.assertTrue(reqHeaders.get(HOST_HEADER).equals("newHost"));
+  }
+
+  @Test
+  public void testHeaderFunctionsWithoutHostHeader(TestContext context) {
+    Rule rule = extractRule("/ruleWithoutHeader");
+    Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
+        monitoringHandler, userProfilePath);
+    MultiMap reqHeaders = new VertxHttpHeaders();
+    reqHeaders.add(HOST_HEADER, "oldHost:1234");
+    String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
+    Assert.assertNull(errorMessage);
+    Assert.assertTrue(reqHeaders.get(HOST_HEADER).equals(DEFAULTHOST + ":" + DEFAULTPORT));
+  }
+
+  @Test
+  public void testHeaderFunctionsDefaultWithoutHostHeader(TestContext context) {
+    Rule rule = extractRule("/ruleWithoutHeader");
+    Forwarder forwarder = new Forwarder(vertx, httpClient, rule, storage, loggingResourceManager,
+        monitoringHandler, userProfilePath);
+    MultiMap reqHeaders = new VertxHttpHeaders();
+    reqHeaders.add(HOST_HEADER, DEFAULTHOST + ":" + DEFAULTPORT);
+    String errorMessage = forwarder.applyHeaderFunctions(logger, reqHeaders);
+    Assert.assertNull(errorMessage);
+    Assert.assertTrue(reqHeaders.get(HOST_HEADER).equals(DEFAULTHOST + ":" + DEFAULTPORT));
+  }
+
+
+}


### PR DESCRIPTION
This is a reduced less invasive solution to the reverted PR https://github.com/swisspush/gateleen/pull/395

The host header will be now always overwritten with the target address as it was before except if there is an explicit Host header given in the routing rules.