### PR TITLE
node / npm version bumped

### DIFF
--- a/gateleen-hook-js/pom.xml
+++ b/gateleen-hook-js/pom.xml
@@ -66,8 +66,8 @@
                         <!-- we need node in phase generate-resources, so do this before-->
                         <phase>initialize</phase>
                         <configuration>
-                            <nodeVersion>v7.5.0</nodeVersion>
-                            <npmVersion>4.2.0</npmVersion>
+                            <nodeVersion>v8.9.4</nodeVersion>
+                            <npmVersion>6.14.8</npmVersion>
                             <nodeDownloadRoot>${nodeDownloadRoot}</nodeDownloadRoot>
                             <npmDownloadRoot>${npmDownloadRoot}</npmDownloadRoot>
                         </configuration>

--- a/gateleen-hook-js/pom.xml
+++ b/gateleen-hook-js/pom.xml
@@ -56,7 +56,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>0.0.22</version>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>install node and npm profile trigged</id>
@@ -66,8 +66,8 @@
                         <!-- we need node in phase generate-resources, so do this before-->
                         <phase>initialize</phase>
                         <configuration>
-                            <nodeVersion>v0.12.2</nodeVersion>
-                            <npmVersion>2.7.5</npmVersion>
+                            <nodeVersion>v7.5.0</nodeVersion>
+                            <npmVersion>4.2.0</npmVersion>
                             <nodeDownloadRoot>${nodeDownloadRoot}</nodeDownloadRoot>
                             <npmDownloadRoot>${npmDownloadRoot}</npmDownloadRoot>
                         </configuration>


### PR DESCRIPTION
This is to make the build pass again. There would be even newer versions but to use them would require a little bit more time and there are a few changes that we would like to release within this week.