### PR TITLE
synchronize access to jmte Engine to avoid rare threading issue

### DIFF
--- a/gateleen-core/pom.xml
+++ b/gateleen-core/pom.xml
@@ -72,6 +72,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/gateleen-core/pom.xml
+++ b/gateleen-core/pom.xml
@@ -69,6 +69,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/StringUtils.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/StringUtils.java
@@ -211,11 +211,17 @@ public final class StringUtils {
      * @return the String with replaced wildcard values. Returns the input String when input String or
      * properties are <code>null</code>
      */
-    private static String replacePlainStringWildcardConfigs(String contentWithWildcards,
+    private static synchronized String replacePlainStringWildcardConfigs(String contentWithWildcards,
         Map<String, Object> properties) {
         if (properties == null || contentWithWildcards == null) {
             return contentWithWildcards;
         }
+        /*
+         * Note that this Engine is meant to be thread safe but it actually isn't because the TokenStream used by
+         * the Engine uses a MiniParser which in turn is not thread, see:
+         * https://github.com/HubSpot/jmte/blob/a1177fd89858ef55bb1d92acb4b1bb78bb7cac25/src/com/floreysoft/jmte/token/TokenStream.java#L39
+         * Hence we synchronize access in this method.
+         */
         Engine engine = new Engine();
         return wildcardReplacementEngineIgnition(engine, contentWithWildcards, properties);
     }
@@ -240,7 +246,7 @@ public final class StringUtils {
      * @return the String with replaced wildcard values. Returns the input String when input String or
      * properties are <code>null</code>
      */
-    private static String replaceJsonNonStringAttributeWildcardConfigs(String contentWithWildcards, Map<String, Object> properties) {
+    private static synchronized String replaceJsonNonStringAttributeWildcardConfigs(String contentWithWildcards, Map<String, Object> properties) {
         if (properties == null || contentWithWildcards == null) {
             return contentWithWildcards;
         }
@@ -248,6 +254,12 @@ public final class StringUtils {
         if (contentWithWildcards.indexOf(JSON_NUMERIC_START_TOKEN) < 0) {
             return contentWithWildcards;
         }
+        /*
+         * Note that this Engine is meant to be thread safe but it actually isn't because the TokenStream used by
+         * the Engine uses a MiniParser which in turn is not thread safe, see:
+         * https://github.com/HubSpot/jmte/blob/a1177fd89858ef55bb1d92acb4b1bb78bb7cac25/src/com/floreysoft/jmte/token/TokenStream.java#L39
+         * Hence we synchronize access in this method.
+         */
         Engine engine = new Engine();
         engine.setExprStartToken(JSON_NUMERIC_START_TOKEN);
         engine.setExprEndToken(JSON_NUMERIC_END_TOKEN);

--- a/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/StringUtilsTest.java
+++ b/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/StringUtilsTest.java
@@ -11,6 +11,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.testng.Assert;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -137,6 +138,17 @@ public class StringUtilsTest {
         context.assertTrue(result.indexOf("/playground/([^/]*\\\\.html)")>=0);
         context.assertTrue(result.indexOf("\"path\": \"my/test/path\"")>=0);
         context.assertTrue(result.indexOf("\"port\": 123")>=0);
+    }
+
+    /**
+     * Within 10000 invocations and 10 threads we normally see it fail consistently if there is threading issue.
+     */
+    @org.testng.annotations.Test(threadPoolSize = 10, invocationCount = 10000, timeOut = 10000)
+    public void testConcurrentAccessToJmteEngine() {
+        String test = "/playground/[^/]*\\\\.html";
+        String expected = "/playground/[^/]*\\.html";
+        String result = StringUtils.replaceWildcardConfigs(test, new HashMap<>());
+        Assert.assertEquals(expected, result);
     }
 
 }

--- a/gateleen-hook-js/pom.xml
+++ b/gateleen-hook-js/pom.xml
@@ -56,7 +56,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>0.0.22</version>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>install node and npm profile trigged</id>
@@ -66,8 +66,8 @@
                         <!-- we need node in phase generate-resources, so do this before-->
                         <phase>initialize</phase>
                         <configuration>
-                            <nodeVersion>v0.12.2</nodeVersion>
-                            <npmVersion>2.7.5</npmVersion>
+                            <nodeVersion>v8.9.4</nodeVersion>
+                            <npmVersion>6.14.8</npmVersion>
                             <nodeDownloadRoot>${nodeDownloadRoot}</nodeDownloadRoot>
                             <npmDownloadRoot>${npmDownloadRoot}</npmDownloadRoot>
                         </configuration>

--- a/gateleen-test/pom.xml
+++ b/gateleen-test/pom.xml
@@ -165,6 +165,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,11 @@
                 <version>4.13.1</version>
             </dependency>
             <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>7.4.0</version>
+            </dependency>
+            <dependency>
                 <groupId>redis.clients</groupId>
                 <artifactId>jedis</artifactId>
                 <version>2.9.0</version>


### PR DESCRIPTION
This is basically a workaround for something that should be addressed in https://github.com/HubSpot/jmte. However, there has been no activity in this project for the last 7 years or so. 

Also, there is some low level byte code compilation going on in jmte, not sure if this will continue to work with future Java versions. Actually I'm also uncertain if it does with current ones, I believe we do not use this feature in gateleen, so we don't necessarily see issues (and also do not necessarily care if there are issues).

We might want to look into alternatives to jmte to get rid of the dependency and this workaround.


Note: Also contains https://github.com/swisspush/gateleen/pull/405 to hopefully get a successful build.