### PR TITLE
allow to configure the HttpClientOptions.DEFAULT_KEEP_ALIVE_TIMEOUT on routes through system property

### DIFF
--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
@@ -33,6 +33,9 @@ public class Route {
     private static final boolean CLIENT_DEFAULT_EXPAND_IN_STORAGE = false;
     private static final int CLIENT_DEFAULT_LOG_EXPIRY = 4 * 3600;
 
+    private static final String HTTP_CONNECTION_KEEP_ALIVE_TIMEOUT = "org.swisspush.gateleen.routing.rule.http.connection.keep.alive.timeout";
+    private static int keepAliveTimeout;
+
     private static final Pattern URL_PARSE_PATTERN = Pattern.compile("^(?<scheme>https?)://(?<host>[^/:]+)(:(?<port>[0-9]+))?(?<path>/.*)$");
     private static final Logger LOG = LoggerFactory.getLogger(Route.class);
     private static final Logger CLEANUP_LOGGER = LoggerFactory.getLogger(Route.class.getName() + "Cleanup");
@@ -50,6 +53,15 @@ public class Route {
     private HttpClient client;
     private Forwarder forwarder;
     private HttpClient selfClient;
+
+    static {
+        String keepAliveTimeoutProperty =  System.getProperty(HTTP_CONNECTION_KEEP_ALIVE_TIMEOUT);
+        if (keepAliveTimeoutProperty != null) {
+            keepAliveTimeout = Integer.parseInt(keepAliveTimeoutProperty);
+        } else {
+            keepAliveTimeout = HttpClientOptions.DEFAULT_KEEP_ALIVE_TIMEOUT;
+        }
+    }
 
     /**
      * Creates a new instance of a Route.
@@ -98,6 +110,7 @@ public class Route {
 
         rule.setTimeout(1000 * CLIENT_DEFAULT_TIMEOUT_SEC);
         rule.setKeepAlive(CLIENT_DEFAULT_KEEP_ALIVE);
+        rule.setKeepAliveTimeout(keepAliveTimeout);
         rule.setExpandOnBackend(CLIENT_DEFAULT_EXPAND_ON_BACKEND);
         rule.setStorageExpand(CLIENT_DEFAULT_EXPAND_IN_STORAGE);
         rule.setLogExpiry(CLIENT_DEFAULT_LOG_EXPIRY);

--- a/gateleen-kafka/src/test/java/org/swisspush/gateleen/kafka/KafkaHandlerTest.java
+++ b/gateleen-kafka/src/test/java/org/swisspush/gateleen/kafka/KafkaHandlerTest.java
@@ -35,6 +35,7 @@ import java.util.regex.Pattern;
 import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 import static org.swisspush.gateleen.core.configuration.ConfigurationResourceManager.CONFIG_RESOURCE_CHANGED_ADDRESS;
@@ -128,15 +129,15 @@ public class KafkaHandlerTest {
         context.assertFalse(handler.isInitialized());
 
         handler.initialize().setHandler(event -> {
-            verify(repository, times(2)).closeAll();
-
+            // depending whether resourceChanged fires or not we get one or two invocations
+            verify(repository, atLeastOnce()).closeAll();
             Map<String, String> configs_1 = new HashMap<String, String>() {{
                 put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
                 put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
                 put("bootstrap.servers", "localhost:9094");
                 put("acks", "all");
             }};
-            verify(repository, times(2)).addKafkaProducer(eq(new KafkaConfiguration(Pattern.compile("my.properties.topic.*"), configs_1)));
+            verify(repository, atLeastOnce()).addKafkaProducer(eq(new KafkaConfiguration(Pattern.compile("my.properties.topic.*"), configs_1)));
             verifyZeroInteractions(kafkaMessageSender);
             context.assertTrue(handler.isInitialized());
             async.complete();

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Rule.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Rule.java
@@ -24,6 +24,7 @@ public class Rule {
     private int poolSize;
     private int maxWaitQueueSize;
     private boolean keepAlive;
+    private int keepAliveTimeout;
     private boolean expandOnBackend;
     private boolean deltaOnBackend;
     private boolean storageExpand;
@@ -122,6 +123,20 @@ public class Rule {
 
     public void setKeepAlive(boolean keepAlive) {
         this.keepAlive = keepAlive;
+    }
+
+    /**
+     * Gets the keep-alive timeout in seconds, see {@link HttpClientOptions#DEFAULT_KEEP_ALIVE_TIMEOUT}
+     */
+    public int getKeepAliveTimeout() {
+        return keepAliveTimeout;
+    }
+
+    /**
+     * Sets the keep-alive timeout in seconds, see {@link HttpClientOptions#DEFAULT_KEEP_ALIVE_TIMEOUT}
+     */
+    public void setKeepAliveTimeout(int keepAliveTimeoutSeconds) {
+        this.keepAliveTimeout = keepAliveTimeoutSeconds;
     }
 
     public boolean isExpandOnBackend() { return expandOnBackend; }
@@ -238,14 +253,14 @@ public class Rule {
 
     public HttpClientOptions buildHttpClientOptions() {
         final HttpClientOptions options = new HttpClientOptions()
-                .setDefaultHost   (getHost    ())
-                .setDefaultPort   (getPort    ())
-                .setMaxPoolSize   (getPoolSize())
-                .setConnectTimeout(getTimeout ())
-                .setKeepAlive     (isKeepAlive())
-                .setPipelining    (false        )
-                .setMaxWaitQueueSize(getMaxWaitQueueSize())
-        ;
+                .setDefaultHost(getHost())
+                .setDefaultPort(getPort())
+                .setMaxPoolSize(getPoolSize())
+                .setConnectTimeout(getTimeout())
+                .setKeepAlive(isKeepAlive())
+                .setKeepAliveTimeout(getKeepAliveTimeout())
+                .setPipelining(false)
+                .setMaxWaitQueueSize(getMaxWaitQueueSize());
         if ("https".equals(getScheme())) {
             options.setSsl(true).setVerifyHost(false).setTrustAll(true);
         }

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RuleFactory.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RuleFactory.java
@@ -1,6 +1,7 @@
 package org.swisspush.gateleen.routing;
 
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.ProxyOptions;
@@ -87,6 +88,7 @@ public class RuleFactory {
 
             int defaultTimeoutSec = 30;
             ruleObj.setTimeout(1000 * rule.getInteger("timeout", defaultTimeoutSec));
+            ruleObj.setKeepAliveTimeout(rule.getInteger("keepAliveTimeout", HttpClientOptions.DEFAULT_KEEP_ALIVE_TIMEOUT));
             ruleObj.setPoolSize(rule.getInteger(Rule.CONNECTION_POOL_SIZE_PROPERTY_NAME, Rule.CONNECTION_POOL_SIZE_DEFAULT_VALUE));
             ruleObj.setMaxWaitQueueSize(rule.getInteger(Rule.MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME, Rule.MAX_WAIT_QUEUE_SIZE_DEFAULT_VALUE));
             ruleObj.setKeepAlive(rule.getBoolean("keepAlive", true));

--- a/gateleen-routing/src/main/resources/gateleen_routing_schema_routing_rules
+++ b/gateleen-routing/src/main/resources/gateleen_routing_schema_routing_rules
@@ -57,6 +57,11 @@
 					"type": "integer",
 					"default": 30
 				},
+				"keepAliveTimeout": {
+                    "description": "The keep alive timeout for HTTP/1.1 connections.",
+                    "type": "integer",
+                    "default": 60
+                },
 				"connectionPoolSize": {
 					"description": "The maximum number of concurrent connections to the backend. Has no effect for local/storage forwarding.",
 					"type": "integer",

--- a/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/RuleFactoryTest.java
+++ b/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/RuleFactoryTest.java
@@ -57,7 +57,24 @@ public class RuleFactoryTest {
 
         context.assertTrue(rules.size() == 2);
         context.assertEquals("someserver1", rules.get(0).getHost());
+        context.assertEquals(60, rules.get(0).getKeepAliveTimeout());
         context.assertEquals("someserver2", rules.get(1).getHost());
+        context.assertEquals(60, rules.get(1).getKeepAliveTimeout());
+    }
+
+    @Test
+    public void testRuleWiteKeepAliveTimeoutParsing(TestContext context) throws ValidationException {
+        String rule = "{"
+                + "  \"/gateleen/rule/keep-alive\": {"
+                + "    \"description\": \"Keep Alive Rule 1\","
+                + "    \"url\": \"https://sawasdee.hello.com/gateleen/rule/keep-alive/1\","
+                + "    \"keepAliveTimeout\": 28"
+                + "  }"
+                + "}";
+
+        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule));
+        context.assertTrue(rules.size() == 1);
+        context.assertEquals(28, rules.get(0).getKeepAliveTimeout());
     }
 
     @Test


### PR DESCRIPTION
As per title. With this PR we allow to configure the vert.x property. If not configured the default kicks in as before.