### PR TITLE
Discontinued to use testng, RedisBasedLock.acquireLock() fixed

### DIFF
--- a/gateleen-core/pom.xml
+++ b/gateleen-core/pom.xml
@@ -69,11 +69,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.testng</groupId>-->
-<!--            <artifactId>testng</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
     </dependencies>
     <build>
         <plugins>

--- a/gateleen-core/pom.xml
+++ b/gateleen-core/pom.xml
@@ -69,11 +69,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.testng</groupId>-->
+<!--            <artifactId>testng</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
     </dependencies>
     <build>
         <plugins>

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/lock/impl/RedisBasedLock.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/lock/impl/RedisBasedLock.java
@@ -53,7 +53,7 @@ public class RedisBasedLock implements Lock {
     @Override
     public Future<Boolean> acquireLock(String lock, String token, long lockExpiryMs) {
         Promise<Boolean> promise = Promise.promise();
-        redisSetWithOptions(lock, token, true, lockExpiryMs, event -> {
+        redisSetWithOptions(buildLockKey(lock), token, true, lockExpiryMs, event -> {
             if (event.succeeded()) {
                 if (event.result() != null) {
                     promise.complete("OK".equalsIgnoreCase(event.result().toString()));

--- a/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/StringUtilsTest.java
+++ b/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/StringUtilsTest.java
@@ -7,6 +7,8 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -14,6 +16,10 @@ import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for the {@link StringUtils} class
@@ -139,15 +145,23 @@ public class StringUtilsTest {
         context.assertTrue(result.indexOf("\"port\": 123")>=0);
     }
 
-//    /**
-//     * Within 10000 invocations and 10 threads we normally see it fail consistently if there is threading issue.
-//     */
-//    @org.testng.annotations.Test(threadPoolSize = 10, invocationCount = 10000, timeOut = 10000)
-//    public void testConcurrentAccessToJmteEngine() {
-//        String test = "/playground/[^/]*\\\\.html";
-//        String expected = "/playground/[^/]*\\.html";
-//        String result = StringUtils.replaceWildcardConfigs(test, new HashMap<>());
-//        Assert.assertEquals(expected, result);
-//    }
-
+    /**
+     * Within 10000 invocations and 10 threads we normally see it fail consistently if there is threading issue.
+     */
+    @Test
+    public void testConcurrentAccessToJmteEngine() throws InterruptedException {
+        ExecutorService service = Executors.newFixedThreadPool(10);
+        final int invocationCount = 10000;
+        CountDownLatch lock = new CountDownLatch(invocationCount);
+        for (int i = 0; i < invocationCount; i++) {
+            service.submit(() -> {
+                String test = "/playground/[^/]*\\\\.html";
+                String expected = "/playground/[^/]*\\.html";
+                String result = StringUtils.replaceWildcardConfigs(test, new HashMap<>());
+                Assert.assertEquals(expected, result);
+                lock.countDown();
+            });
+        }
+        lock.await(10, TimeUnit.SECONDS);
+    }
 }

--- a/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/StringUtilsTest.java
+++ b/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/StringUtilsTest.java
@@ -11,7 +11,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.testng.Assert;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -140,15 +139,15 @@ public class StringUtilsTest {
         context.assertTrue(result.indexOf("\"port\": 123")>=0);
     }
 
-    /**
-     * Within 10000 invocations and 10 threads we normally see it fail consistently if there is threading issue.
-     */
-    @org.testng.annotations.Test(threadPoolSize = 10, invocationCount = 10000, timeOut = 10000)
-    public void testConcurrentAccessToJmteEngine() {
-        String test = "/playground/[^/]*\\\\.html";
-        String expected = "/playground/[^/]*\\.html";
-        String result = StringUtils.replaceWildcardConfigs(test, new HashMap<>());
-        Assert.assertEquals(expected, result);
-    }
+//    /**
+//     * Within 10000 invocations and 10 threads we normally see it fail consistently if there is threading issue.
+//     */
+//    @org.testng.annotations.Test(threadPoolSize = 10, invocationCount = 10000, timeOut = 10000)
+//    public void testConcurrentAccessToJmteEngine() {
+//        String test = "/playground/[^/]*\\\\.html";
+//        String expected = "/playground/[^/]*\\.html";
+//        String result = StringUtils.replaceWildcardConfigs(test, new HashMap<>());
+//        Assert.assertEquals(expected, result);
+//    }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -347,11 +347,6 @@
                 <version>4.13.1</version>
             </dependency>
             <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>7.4.0</version>
-            </dependency>
-            <dependency>
                 <groupId>redis.clients</groupId>
                 <artifactId>jedis</artifactId>
                 <version>3.7.0</version>


### PR DESCRIPTION
The build still passed even some tests failed this ways

Failure in JUnit mode for class org.swisspush.gateleen.core.logging.RequestLoggerTest
org.testng.TestNGException: 
Failure in JUnit mode for class org.swisspush.gateleen.core.logging.RequestLoggerTest
    at org.testng.junit.JUnit4TestRunner.start(JUnit4TestRunner.java:115)
    at org.testng.junit.JUnit4TestRunner.run(JUnit4TestRunner.java:66)
    at org.testng.TestRunner$1.run(TestRunner.java:672)
    at java.base/java.util.ArrayList.forEach(ArrayList.java:1540)



With this PR, we discontinue to use testng, only one single test had to be rewritten.

Also, after this was done, some unit tests failed around the RedisBasedLock, hence also a related bug fix in this PR.