### PR TITLE
Remove all duplicated headers

### DIFF
--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
@@ -78,22 +78,21 @@ public class HttpHeaderUtil {
     }
 
     /**
-     * Merges headers, makes sure that only one value of header ends up in the result.
+     * Merges headers, makes sure that only one value of all header ends up in the result.
      *
      * @param context optional context information to be used for logging purposes, not used for the actual merge
+     *                Note: This is not 100% in line with https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2 to be further looked into.
      */
     public static void mergeHeaders(@Nonnull MultiMap destination, @Nonnull MultiMap source, @Nullable String context) {
         source.forEach(sourceHeader -> {
             if (destination.contains(sourceHeader.getKey())) {
                 String destinationValue = destination.get(sourceHeader.getKey());
                 String sourceValue = source.get(sourceHeader.getKey());
-                if (!(destinationValue.isEmpty() || sourceValue.isEmpty())) {
-                    if (!destinationValue.equals(sourceValue)) {
-                        LOG.error("{}} values do not match {} != {} for request {}",
-                                sourceHeader.getKey(), destinationValue, sourceValue, context);
-                    }
-                    destination.remove(sourceHeader.getKey());
+                if (!destinationValue.equals(sourceValue)) {
+                    LOG.error("{}} values do not match {} != {} for request {}",
+                            sourceHeader.getKey(), destinationValue, sourceValue, context);
                 }
+                destination.remove(sourceHeader.getKey());
             }
         });
         destination.addAll(source);

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
@@ -78,20 +78,24 @@ public class HttpHeaderUtil {
     }
 
     /**
-     * Merges headers, makes sure that only one value of all header ends up in the result.
+     * Merges headers, makes sure that only one value of all headers ends up in the destination MultiMap.
+     *
+     * Note: This is not 100% in line with https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2 to be further looked into.
      *
      * @param context optional context information to be used for logging purposes, not used for the actual merge
-     *                Note: This is not 100% in line with https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2 to be further looked into.
+     *
      */
     public static void mergeHeaders(@Nonnull MultiMap destination, @Nonnull MultiMap source, @Nullable String context) {
         source.forEach(sourceHeader -> {
             if (destination.contains(sourceHeader.getKey())) {
+                // we already have such a header
                 String destinationValue = destination.get(sourceHeader.getKey());
                 String sourceValue = source.get(sourceHeader.getKey());
                 if (!destinationValue.equals(sourceValue)) {
                     LOG.error("{}} values do not match {} != {} for request {}",
                             sourceHeader.getKey(), destinationValue, sourceValue, context);
                 }
+                // remove it from the destination
                 destination.remove(sourceHeader.getKey());
             }
         });

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/HttpHeaderUtil.java
@@ -1,19 +1,14 @@
 package org.swisspush.gateleen.core.util;
 
 import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpServerResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
 
 
 public class HttpHeaderUtil {
@@ -83,30 +78,25 @@ public class HttpHeaderUtil {
     }
 
     /**
-     * Merges headers, makes sure that only one value of header {@link HttpRequestHeader#CONTENT_LENGTH} ends up in the result.
+     * Merges headers, makes sure that only one value of header ends up in the result.
      *
      * @param context optional context information to be used for logging purposes, not used for the actual merge
      */
     public static void mergeHeaders(@Nonnull MultiMap destination, @Nonnull MultiMap source, @Nullable String context) {
-        String destinationContentLength = "";
-        String sourceContentLength = "";
-
-        if (HttpRequestHeader.containsHeader(destination, HttpRequestHeader.CONTENT_LENGTH)) {
-            destinationContentLength = destination.get(HttpRequestHeader.CONTENT_LENGTH.getName());
-        }
-        if (HttpRequestHeader.containsHeader(source, HttpRequestHeader.CONTENT_LENGTH)) {
-            sourceContentLength = source.get(HttpRequestHeader.CONTENT_LENGTH.getName());
-        }
-        if (destinationContentLength.isEmpty() || sourceContentLength.isEmpty()) {
-            destination.addAll(source);
-        } else {
-            if (!destinationContentLength.equals(sourceContentLength)) {
-                LOG.error("Content-Length values do not match {} != {} for request {}",
-                        destinationContentLength, sourceContentLength, context);
+        source.forEach(sourceHeader -> {
+            if (destination.contains(sourceHeader.getKey())) {
+                String destinationValue = destination.get(sourceHeader.getKey());
+                String sourceValue = source.get(sourceHeader.getKey());
+                if (!(destinationValue.isEmpty() || sourceValue.isEmpty())) {
+                    if (!destinationValue.equals(sourceValue)) {
+                        LOG.error("{}} values do not match {} != {} for request {}",
+                                sourceHeader.getKey(), destinationValue, sourceValue, context);
+                    }
+                    destination.remove(sourceHeader.getKey());
+                }
             }
-            destination.remove(HttpRequestHeader.CONTENT_LENGTH.getName());
-            destination.addAll(source);
-        }
+        });
+        destination.addAll(source);
     }
 }
 

--- a/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/HttpHeaderUtilTest.java
+++ b/gateleen-core/src/test/java/org/swisspush/gateleen/core/util/HttpHeaderUtilTest.java
@@ -7,6 +7,8 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Map;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 
@@ -87,6 +89,9 @@ public class HttpHeaderUtilTest {
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         headers.add(HttpRequestHeader.CONTENT_LENGTH.getName(), "123");
         headers.add("host", "host:1234");
+        headers.add("test-1", "1");
+        headers.add("test-2", "");
+        headers.add("test-3", "");
 
         MultiMap headersToForward = MultiMap.caseInsensitiveMultiMap();
         headersToForward.add(HttpRequestHeader.CONTENT_LENGTH.getName(), "123");
@@ -108,5 +113,27 @@ public class HttpHeaderUtilTest {
         testContext.assertTrue(HttpHeaderUtil.hasMatchingHeader(headers, Pattern.compile("Content-Length: 126")));
         testContext.assertTrue(HttpHeaderUtil.hasMatchingHeader(headers, Pattern.compile("host: host:1234")));
         testContext.assertTrue(HttpHeaderUtil.hasMatchingHeader(headers, Pattern.compile("dummy-header: 123")));
+
+        headersToForward = MultiMap.caseInsensitiveMultiMap();
+        headersToForward.add("test-1", "");
+        headersToForward.add("test-2", "2");
+        headersToForward.add("test-3", "");
+
+        HttpHeaderUtil.mergeHeaders(headers, headersToForward, "test");
+
+        headers.forEach(new Consumer<Map.Entry<String, String>>() {
+            @Override
+            public void accept(Map.Entry<String, String> stringStringEntry) {
+                //System.console().printf(stringStringEntry.getKey() + ": " +stringStringEntry.getValue());
+                String value= stringStringEntry.getKey() + ": " +stringStringEntry.getValue();
+            }
+        });
+
+        testContext.assertTrue(HttpHeaderUtil.hasMatchingHeader(headers, Pattern.compile("test-1: ")));
+        testContext.assertTrue(HttpHeaderUtil.hasMatchingHeader(headers, Pattern.compile("test-2: 2")));
+        testContext.assertTrue(HttpHeaderUtil.hasMatchingHeader(headers, Pattern.compile("test-3: ")));
+
+        testContext.assertFalse(HttpHeaderUtil.hasMatchingHeader(headers, Pattern.compile("test-1: 1")));
+        testContext.assertFalse(HttpHeaderUtil.hasMatchingHeader(headers, Pattern.compile("test-2: ")));
     }
 }


### PR DESCRIPTION
With this PR we provide means to remove all duplicated headers, so far we had special treatment for header "Content-Length" only. 