### PR TITLE
Run all the tests in multiple forked VM

### DIFF
--- a/gateleen-test/pom.xml
+++ b/gateleen-test/pom.xml
@@ -280,7 +280,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <systemPropertyVariables>
                         <log4jConfigFile>${basedir}/src/test/resources/log4j.xml</log4jConfigFile>
                         <sel_chrome_driver>${sel_chrome_driver}</sel_chrome_driver>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
