### PR TITLE
End connection when request fails

### DIFF
--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
@@ -426,6 +426,9 @@ public class Forwarder extends AbstractForwarder {
             HttpClientResponse cRes = asyncResult.result();
             if (asyncResult.failed()) {
                 error(asyncResult.cause().getMessage(), req, targetUri);
+                req.response().setStatusCode(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+                req.response().setStatusMessage(asyncResult.cause().getMessage());
+                req.response().end();
                 return;
             }
             monitoringHandler.stopRequestMetricTracking(rule.getMetricName(), startTime, req.uri());


### PR DESCRIPTION
Observed a case where RedisQues doesn't get informed about forwarding issues upon dequeueing: We do not arrive here

https://github.com/swisspush/vertx-redisques/blob/develop/src/main/java/org/swisspush/redisques/RedisQues.java#L1230

I mean

log.info("RedisQues QUEUE_ERROR: Consumer failed " + uid + " queue: " + queue + " (" + reply.cause().getMessage() + ")");

for in-flight requests that are then closed by the remote end.

