### PR TITLE
avoid that the requests are output into 2 logfiles

### DIFF
--- a/gateleen-logging/src/main/java/org/swisspush/gateleen/logging/LoggingHandler.java
+++ b/gateleen-logging/src/main/java/org/swisspush/gateleen/logging/LoggingHandler.java
@@ -72,7 +72,7 @@ public class LoggingHandler {
         this.eventBus = eventBus;
         this.loggingResource = loggingResourceManager.getLoggingResource();
         this.log = RequestLoggerFactory.getLogger(LoggingHandler.class, request);
-
+        ((org.apache.logging.log4j.core.Logger) LogManager.getLogger(DEFAULT_LOGGER)).setAdditive(false);
         boolean stopValidation = false;
         for (Map<String, String> payloadFilter : loggingResource.getPayloadFilters()) {
             if (active || stopValidation) {


### PR DESCRIPTION
In our project the requests also end up in the log file of the server (beside the "requests" log file).  This is a behavior change compared to previous version where log4j1 was in use. With this PR we go back to the original behavior, requests are logged to the "requests" log file only.