### PR TITLE
Consider the number of route instances in a cluster when applying con…

### DIFF
--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -1533,15 +1533,16 @@ public class HookHandler implements LoggableResource {
 
         // Configure connection pool size
         Integer originalPoolSize = jsonHook.getInteger(HttpHook.CONNECTION_POOL_SIZE_PROPERTY_NAME);
-        int appliedPoolSize = 0;
+        int appliedPoolSize;
         if (originalPoolSize != null) {
             appliedPoolSize = Math.floorDiv(originalPoolSize, routeMultiplier);
             if (appliedPoolSize < 1) {
                 appliedPoolSize = originalPoolSize;
             }
+            log.debug("Original pool size is {}, applied size is {}", originalPoolSize, appliedPoolSize);
+            hook.setConnectionPoolSize(appliedPoolSize);
         }
-        log.debug("Original pool size is {}, applied size is {}", originalPoolSize, appliedPoolSize);
-        hook.setConnectionPoolSize(appliedPoolSize);
+
 
         hook.setMaxWaitQueueSize(jsonHook.getInteger(HttpHook.CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME));
         // Configure request timeout

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -445,9 +445,13 @@ public class HookHandler implements LoggableResource {
      * @param readyHandler - the ready handler
      */
     private void registerRouteMultiplierChangeHandler(Handler<Void> readyHandler) {
-        vertx.eventBus().consumer(Router.ROUTE_MULTIPLIER_ADRESS, (Handler<Message<String>>) event -> {
-            log.warn("Update router's pool size multiplier: {}", (event.body() == null ? "<null>" : event.body()));
-            routeMultiplier = Integer.parseInt(event.body());
+        vertx.eventBus().consumer(Router.ROUTE_MULTIPLIER_ADDRESS, (Handler<Message<String>>) event -> {
+            log.info("Updating route multiplier: {}", (event.body() == null ? "<null>" : event.body()));
+            try {
+                routeMultiplier = Integer.parseInt(event.body());
+            } catch (NumberFormatException e) {
+                log.info("failed to parse route multiplier: {}", event.body(), e);
+            }
         });
         // method done / no async processing pending
         readyHandler.handle(null);

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -34,6 +34,7 @@ import org.swisspush.gateleen.queue.expiry.ExpiryCheckHandler;
 import org.swisspush.gateleen.queue.queuing.QueueClient;
 import org.swisspush.gateleen.queue.queuing.QueueProcessor;
 import org.swisspush.gateleen.queue.queuing.RequestQueue;
+import org.swisspush.gateleen.routing.Router;
 import org.swisspush.gateleen.routing.Rule;
 import org.swisspush.gateleen.validation.RegexpValidator;
 import org.swisspush.gateleen.validation.ValidationException;
@@ -106,7 +107,7 @@ public class HookHandler implements LoggableResource {
     private final String hookRootUri;
     private final boolean listableRoutes;
     private final ListenerRepository listenerRepository;
-    private final RouteRepository routeRepository;
+    final RouteRepository routeRepository;
     private final RequestQueue requestQueue;
 
     private final ReducedPropagationManager reducedPropagationManager;
@@ -116,6 +117,7 @@ public class HookHandler implements LoggableResource {
     private final Handler<Void> doneHandler;
 
     private final JsonSchema jsonSchemaHook;
+    private int routeMultiplier;
 
 
     /**
@@ -185,6 +187,14 @@ public class HookHandler implements LoggableResource {
                 requestQueue, listableRoutes, reducedPropagationManager, null, storage);
     }
 
+    public HookHandler(Vertx vertx, HttpClient selfClient, final ResourceStorage storage,
+                       LoggingResourceManager loggingResourceManager, MonitoringHandler monitoringHandler,
+                       String userProfilePath, String hookRootUri, RequestQueue requestQueue, boolean listableRoutes,
+                       ReducedPropagationManager reducedPropagationManager, Handler doneHandler, ResourceStorage hookStorage) {
+        this(vertx, selfClient, storage, loggingResourceManager, monitoringHandler, userProfilePath, hookRootUri,
+                requestQueue, listableRoutes, reducedPropagationManager, doneHandler, hookStorage, Router.DEFAULT_ROUTER_MULTIPLIER);
+    }
+
     /**
      * Creates a new HookHandler.
      *
@@ -200,11 +210,15 @@ public class HookHandler implements LoggableResource {
      * @param reducedPropagationManager reducedPropagationManager
      * @param doneHandler               doneHandler
      * @param hookStorage               hookStorage - where the hooks are stored
+     * @param routeMultiplier           the multiplier that is applied to routes, this is typically the number of nodes in
+     *                                  a cluster multiplied by the number of router instances within a node. Or in other words
+     *                                  the number of {@link Router} instances within a cluster
      */
     public HookHandler(Vertx vertx, HttpClient selfClient, final ResourceStorage userProfileStorage,
                        LoggingResourceManager loggingResourceManager, MonitoringHandler monitoringHandler,
                        String userProfilePath, String hookRootUri, RequestQueue requestQueue, boolean listableRoutes,
-                       ReducedPropagationManager reducedPropagationManager, Handler doneHandler, ResourceStorage hookStorage) {
+                       ReducedPropagationManager reducedPropagationManager, Handler doneHandler, ResourceStorage hookStorage,
+                       int routeMultiplier) {
         log.debug("Creating HookHandler ...");
         this.vertx = vertx;
         this.selfClient = selfClient;
@@ -221,6 +235,7 @@ public class HookHandler implements LoggableResource {
         collectionContentComparator = new CollectionContentComparator();
         this.doneHandler = doneHandler;
         this.hookStorage = hookStorage;
+        this.routeMultiplier = routeMultiplier;
 
         String hookSchema = ResourcesUtils.loadResource("gateleen_hooking_schema_hook", true);
         jsonSchemaHook = JsonSchemaFactory.getInstance().getSchema(hookSchema);
@@ -234,6 +249,7 @@ public class HookHandler implements LoggableResource {
         initMethods.add(this::loadStoredListeners);
         initMethods.add(this::loadStoredRoutes);
         initMethods.add(this::registerCleanupHandler);
+        initMethods.add(this::registerRouteMultiplierChangeHandler);
 
         // ready handler, calls the doneHandler when everything is done and the HookHandler is ready to use
         Handler<Void> readyHandler = new Handler<>() {
@@ -419,6 +435,20 @@ public class HookHandler implements LoggableResource {
         // Receive listener remove notifications
         vertx.eventBus().consumer(REMOVE_ROUTE_ADDRESS, (Handler<Message<String>>) event -> unregisterRoute(event.body()));
 
+        // method done / no async processing pending
+        readyHandler.handle(null);
+    }
+
+    /**
+     * Update all registered router's pool size multiplier
+     *
+     * @param readyHandler - the ready handler
+     */
+    private void registerRouteMultiplierChangeHandler(Handler<Void> readyHandler) {
+        vertx.eventBus().consumer(Router.ROUTE_MULTIPLIER_ADRESS, (Handler<Message<String>>) event -> {
+            log.warn("Update router's pool size multiplier: {}", (event.body() == null ? "<null>" : event.body()));
+            routeMultiplier = Integer.parseInt(event.body());
+        });
         // method done / no async processing pending
         readyHandler.handle(null);
     }
@@ -1498,7 +1528,16 @@ public class HookHandler implements LoggableResource {
         hook.setQueueingStrategy(QueueingStrategyFactory.buildQueueStrategy(storageObject));
 
         // Configure connection pool size
-        hook.setConnectionPoolSize(jsonHook.getInteger(HttpHook.CONNECTION_POOL_SIZE_PROPERTY_NAME));
+        Integer originalPoolSize = jsonHook.getInteger(HttpHook.CONNECTION_POOL_SIZE_PROPERTY_NAME);
+        int appliedPoolSize = 0;
+        if (originalPoolSize != null) {
+            appliedPoolSize = Math.floorDiv(originalPoolSize, routeMultiplier);
+            if (appliedPoolSize < 1) {
+                appliedPoolSize = originalPoolSize;
+            }
+        }
+        log.debug("Original pool size is {}, applied size is {}", originalPoolSize, appliedPoolSize);
+        hook.setConnectionPoolSize(appliedPoolSize);
 
         hook.setMaxWaitQueueSize(jsonHook.getInteger(HttpHook.CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME));
         // Configure request timeout

--- a/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
+++ b/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
@@ -599,7 +599,7 @@ public class HookHandlerTest {
         }
 
         // Update multiplier
-        vertx.eventBus().publish(Router.ROUTE_MULTIPLIER_ADRESS, "2");
+        vertx.eventBus().publish(Router.ROUTE_MULTIPLIER_ADDRESS, "2");
         Thread.sleep(2000);
         // Old on should be expired
 

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Router.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Router.java
@@ -47,7 +47,7 @@ public class Router implements Refreshable, LoggableResource, ConfigurationResou
     public static final String ROUTER_STATE_MAP = "router_state_map";
     public static final String ROUTER_BROKEN_KEY = "router_broken";
     public static final String REQUEST_HOPS_LIMIT_PROPERTY = "request.hops.limit";
-    public static final String ROUTE_MULTIPLIER_ADRESS = "gateleen.route-multiplier";
+    public static final String ROUTE_MULTIPLIER_ADDRESS = "gateleen.route-multiplier";
     private final String rulesUri;
     private final String userProfileUri;
     private final String serverUri;
@@ -263,7 +263,7 @@ public class Router implements Refreshable, LoggableResource, ConfigurationResou
             }
         }));
 
-        vertx.eventBus().consumer(ROUTE_MULTIPLIER_ADRESS, (Handler<Message<String>>) event -> {
+        vertx.eventBus().consumer(ROUTE_MULTIPLIER_ADDRESS, (Handler<Message<String>>) event -> {
             log.debug("Updating router's pool size multiplier: {}", (event.body() == null ? "<null>" : event.body()));
             this.routeMultiplier = Integer.parseInt(event.body());
             vertx.eventBus().publish(Address.RULE_UPDATE_ADDRESS, true);

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RouterBuilder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RouterBuilder.java
@@ -46,6 +46,7 @@ public class RouterBuilder {
     private String configurationResourcePath;
     private ArrayList<Handler<Void>> doneHandlers;
     private HttpClientFactory httpClientFactory;
+    private int routeMultiplier = Router.DEFAULT_ROUTER_MULTIPLIER;
 
     RouterBuilder() {
         // PackagePrivate, as clients should use "Router.builder()" and not this class here directly.
@@ -93,6 +94,7 @@ public class RouterBuilder {
                 storagePort,
                 defaultRouteTypes,
                 httpClientFactory,
+                routeMultiplier,
                 doneHandlersArray
         );
         if (resourceLoggingEnabled) {
@@ -247,4 +249,9 @@ public class RouterBuilder {
         return this;
     }
 
+    public RouterBuilder withRouteMultiplier(int routeMultiplier) {
+        ensureNotBuilt();
+        this.routeMultiplier = routeMultiplier;
+        return this;
+    }
 }

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RuleProvider.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RuleProvider.java
@@ -30,14 +30,19 @@ public class RuleProvider {
     private String routingRulesSchema;
     private ResourceStorage storage;
     final Map<String, Object> properties;
+    private int routeMultiplier;
 
     private List<RuleChangesObserver> observers = new ArrayList<>();
 
     public RuleProvider(Vertx vertx, String rulesPath, ResourceStorage storage, Map<String, Object> properties) {
+        this(vertx, rulesPath, storage, properties, Router.DEFAULT_ROUTER_MULTIPLIER);
+    }
+
+    public RuleProvider(Vertx vertx, String rulesPath, ResourceStorage storage, Map<String, Object> properties, int routeMultiplier) {
         this.rulesPath = rulesPath;
         this.storage = storage;
         this.properties = properties;
-
+        this.routeMultiplier = routeMultiplier;
         routingRulesSchema = ResourcesUtils.loadResource("gateleen_routing_schema_routing_rules", true);
 
         notifyRuleChangesObservers();
@@ -73,7 +78,7 @@ public class RuleProvider {
         storage.get(rulesPath, buffer -> {
             if (buffer != null) {
                 try {
-                    List<Rule> rules = new RuleFactory(properties, routingRulesSchema).parseRules(buffer);
+                    List<Rule> rules = new RuleFactory(properties, routingRulesSchema).parseRules(buffer, routeMultiplier);
                     promise.complete(rules);
                 } catch (ValidationException e) {
                     log.error("Could parse routing rules", e);

--- a/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/RuleFactoryTest.java
+++ b/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/RuleFactoryTest.java
@@ -53,7 +53,7 @@ public class RuleFactoryTest {
         properties.put("gateleen.test.prop.1", "http://someserver1/");
         properties.put("gateleen.test.prop.2", "http://someserver2/");
 
-        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule));
+        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule), Router.DEFAULT_ROUTER_MULTIPLIER);
 
         context.assertTrue(rules.size() == 2);
         context.assertEquals("someserver1", rules.get(0).getHost());
@@ -72,7 +72,7 @@ public class RuleFactoryTest {
                 + "  }"
                 + "}";
 
-        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule));
+        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule), Router.DEFAULT_ROUTER_MULTIPLIER);
         context.assertTrue(rules.size() == 1);
         context.assertEquals(28, rules.get(0).getKeepAliveTimeout());
     }
@@ -96,7 +96,7 @@ public class RuleFactoryTest {
         properties.put("gateleen.test.prop.1", "http://someserver1/");
         properties.put("gateleen.test.prop.2", "http://someserver2/");
 
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -116,7 +116,7 @@ public class RuleFactoryTest {
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
         properties.put("gateleen.test.prop.2", "http://someserver2/");
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class RuleFactoryTest {
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
         properties.put("gateleen.test.prop.2", "http://someserver2/");
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -153,7 +153,7 @@ public class RuleFactoryTest {
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
         properties.put("gateleen.test.prop.2", "http://someserver2/");
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -181,7 +181,7 @@ public class RuleFactoryTest {
         properties.put("gateleen.test.prop.1", "http://someserver1/");
         properties.put("gateleen.test.prop.2", "http://someserver2/");
         properties.put("gateleen.test.prop.3", "http://someserver3/");
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -204,7 +204,7 @@ public class RuleFactoryTest {
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
         properties.put("gateleen.test.prop.2", "http://someserver2/");
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -227,7 +227,7 @@ public class RuleFactoryTest {
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
         properties.put("gateleen.test.prop.2", "http://someserver2/");
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -242,7 +242,7 @@ public class RuleFactoryTest {
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
 
-        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(expandOnBackendRule));
+        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(expandOnBackendRule), Router.DEFAULT_ROUTER_MULTIPLIER);
 
         context.assertTrue(rules.size() == 1);
         context.assertEquals(true, rules.get(0).isExpandOnBackend());
@@ -260,7 +260,7 @@ public class RuleFactoryTest {
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
 
-        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(deltaOnBackendRule));
+        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(deltaOnBackendRule), Router.DEFAULT_ROUTER_MULTIPLIER);
 
         context.assertTrue(rules.size() == 1);
         context.assertEquals(true, rules.get(0).isDeltaOnBackend());
@@ -290,7 +290,7 @@ public class RuleFactoryTest {
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
 
-        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(storageExpandRule));
+        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(storageExpandRule), Router.DEFAULT_ROUTER_MULTIPLIER);
 
         context.assertEquals(3, rules.size());
         context.assertTrue(rules.get(0).isStorageExpand(), "Rule has property 'storageExpand' with value true. So isStorageExpand() should return true");
@@ -325,7 +325,7 @@ public class RuleFactoryTest {
                 "}";
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -343,7 +343,7 @@ public class RuleFactoryTest {
                 "}";
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -359,7 +359,7 @@ public class RuleFactoryTest {
                 "}";
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -377,7 +377,7 @@ public class RuleFactoryTest {
                 "}";
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -393,7 +393,7 @@ public class RuleFactoryTest {
                 "}";
 
         properties.put("gateleen.test.prop.1", "http://someserver1:1234:1234/"); // port information is not valid
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -410,7 +410,7 @@ public class RuleFactoryTest {
                 "}";
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -428,7 +428,7 @@ public class RuleFactoryTest {
                 "}";
 
         properties.put("gateleen.test.prop.1", "http://someserver1/");
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -447,7 +447,7 @@ public class RuleFactoryTest {
                 "  }\n" +
                 "}";
 
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -464,7 +464,7 @@ public class RuleFactoryTest {
                 "  }\n" +
                 "}";
 
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -501,7 +501,7 @@ public class RuleFactoryTest {
                 "  }\n" +
                 "}";
 
-        List<Rule> rulesList = new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules));
+        List<Rule> rulesList = new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules), Router.DEFAULT_ROUTER_MULTIPLIER);
 
         context.assertEquals(4, rulesList.size());
 
@@ -542,7 +542,7 @@ public class RuleFactoryTest {
                 + "  }"
                 + "}";
 
-        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule));
+        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule), Router.DEFAULT_ROUTER_MULTIPLIER);
 
         context.assertTrue(rules.size() == 2);
         context.assertEquals("someserver1", rules.get(0).getHost());
@@ -561,7 +561,7 @@ public class RuleFactoryTest {
                 "  }\n" +
                 "}";
 
-        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule));
+        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule), Router.DEFAULT_ROUTER_MULTIPLIER);
 
         context.assertTrue(rules.size() == 1);
         context.assertEquals("someserver1", rules.get(0).getHost());
@@ -580,7 +580,7 @@ public class RuleFactoryTest {
                 "  }\n" +
                 "}";
 
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -594,7 +594,7 @@ public class RuleFactoryTest {
                 "  }\n" +
                 "}";
 
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(simpleExampleRule), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -611,7 +611,7 @@ public class RuleFactoryTest {
                 "  }\n" +
                 "}";
 
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rules), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -625,7 +625,7 @@ public class RuleFactoryTest {
                 "  }\n" +
                 "}";
 
-        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(validRule));
+        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(validRule), Router.DEFAULT_ROUTER_MULTIPLIER);
 
         context.assertTrue(rules.size() == 1);
 
@@ -645,7 +645,7 @@ public class RuleFactoryTest {
                 "  }\n" +
                 "}";
 
-        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule));
+        List<Rule> rules =  new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule), Router.DEFAULT_ROUTER_MULTIPLIER);
 
         context.assertTrue(rules.size() == 1);
         context.assertTrue(rules.get(0).getMethods().length == 2);
@@ -663,7 +663,7 @@ public class RuleFactoryTest {
                 "  }\n" +
                 "}";
 
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -678,7 +678,7 @@ public class RuleFactoryTest {
                 "  }\n" +
                 "}";
 
-        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule));
+        new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule), Router.DEFAULT_ROUTER_MULTIPLIER);
     }
 
     @Test
@@ -690,9 +690,35 @@ public class RuleFactoryTest {
                 "  }\n" +
                 "}";
 
-        List<Rule> rules = new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule));
+        List<Rule> rules = new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule), Router.DEFAULT_ROUTER_MULTIPLIER);
 
         context.assertTrue(rules.size() == 1);
         context.assertEquals(Pattern.compile("x-foobar: true").pattern(), rules.get(0).getHeadersFilterPattern().pattern());
+    }
+
+    @Test
+    public void testConnectionPool(TestContext context) throws ValidationException {
+        String rule = "{\n" +
+                "  \"/gateleen/rule/1\":  {\n" +
+                "    \"description\": \"Test rule 1\",\n" +
+                "    \"headersFilter\": \"x-foobar: true\",\n" +
+                "    \"connectionPoolSize\": 10\n" +
+                "  }\n" +
+                "}";
+
+        List<Rule> rules = new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule), Router.DEFAULT_ROUTER_MULTIPLIER);
+
+        context.assertTrue(rules.size() == 1);
+        context.assertEquals(10, rules.get(0).getPoolSize());
+
+        rules = new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule), 2);
+
+        context.assertTrue(rules.size() == 1);
+        context.assertEquals(5, rules.get(0).getPoolSize());
+
+        rules = new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule), 3);
+
+        context.assertTrue(rules.size() == 1);
+        context.assertEquals(3, rules.get(0).getPoolSize());
     }
 }


### PR DESCRIPTION
…figured connection pool sizes.

So far the connection pool size configured on static routes or route hooks, e.g.
 
  "/to/my-backend/(.*)": {
    "url": "http://host.domain.com:7022/$1",
    "connectionPoolSize": 7,
  },

was applied on a per cluster node based AND also on a per router instance base if there were multiple instances. In a case where the number of nodes in a cluster varies (e.g. scaling up is performed due to high load or similar) then the number of concurrent active connections is higher compared to what is configured. This can be confusing and/or actually lead to situations where the backend starts to refuse connection attempts.

With this PR we change this behavior and divide the configured connection pool size by the number of router instances (a so called "route multiplier") which can be passed in and updated at runtime through the event bus. To actually pass in the "route multiplier" is optional, if not passed in things remain unchanged.