### PR TITLE
MSOP-6438: Handle edge-case in ConnClose responses

### DIFF
--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
@@ -49,7 +49,8 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.lang.Long.parseLong;
 import static org.swisspush.gateleen.core.util.HttpHeaderUtil.removeNonForwardHeaders;
 import static org.swisspush.gateleen.core.util.StatusCode.BAD_GATEWAY;
 import static org.swisspush.gateleen.core.util.StatusCode.INTERNAL_SERVER_ERROR;
@@ -692,6 +693,31 @@ public class Forwarder extends AbstractForwarder {
                     LOG.isTraceEnabled() ? new NullPointerException("connection") : null);
             return;
         }
+        /* Damn! I just need `shutdown(s, SHUT_WR)`! But now I need to guess-around
+         * with some unneccessary timeouts :(  */
+        /* Q: Why evaluating the timeout value this way?
+         * A: https://github.com/swisspost/gateleen/pull/744#discussion_r3049404951   */
+        long vertxConnShutdownTimeoutMs;
+        String timeoutFromReqHdrAsStr = req.headers().get("x-timeout");
+        if (timeoutFromReqHdrAsStr != null) {
+            /* try to use timeout from the most recent request */
+            try {
+                /* no documentation anywhere, so we have to assume header is in millis? */
+                vertxConnShutdownTimeoutMs = parseLong(timeoutFromReqHdrAsStr);
+            } catch (NumberFormatException ex) {
+                LOG.info("parseLong({}): {}", timeoutFromReqHdrAsStr, ex.getMessage(), LOG.isDebugEnabled() ? ex : null);
+                vertxConnShutdownTimeoutMs = (rule != null) ? rule.getTimeout() : 0;
+            }
+        } else {
+            /* if most recent request had no value, fallback to the value configured
+             * via rule. As there's no documentation anywhere, we have to assume
+             * getter returns millis? */
+            vertxConnShutdownTimeoutMs = (rule != null) ? rule.getTimeout() : 0;
+        }
+        if (vertxConnShutdownTimeoutMs < 1000) {
+            LOG.debug("Refuse tailResponseTimeoutMs {}ms, will go with at least 1000ms", vertxConnShutdownTimeoutMs);
+            vertxConnShutdownTimeoutMs = 1000;
+        }
         /* Vertx API seems not to have any way to do what we need (eg `shutdown(req, SHUT_WR)`)
          * So we have to use this less accurate alternative, which is similar to a
          * `shutdown(req, SHUT_RDWR)`, but it will await pending data on the
@@ -701,7 +727,7 @@ public class Forwarder extends AbstractForwarder {
          * as it causes undesired effects like
          * https://jira.post.ch/browse/MSOP-6438
          * under edge-case conditions.  */
-        conn.shutdown(300, SECONDS).onFailure((Throwable ex) -> {
+        conn.shutdown(vertxConnShutdownTimeoutMs, MILLISECONDS).onFailure((Throwable ex) -> {
             LOG.info("{}", ex, LOG.isDebugEnabled() ? ex : null);
         });
     }

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
@@ -49,6 +49,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.swisspush.gateleen.core.util.HttpHeaderUtil.removeNonForwardHeaders;
 import static org.swisspush.gateleen.core.util.StatusCode.BAD_GATEWAY;
 import static org.swisspush.gateleen.core.util.StatusCode.INTERNAL_SERVER_ERROR;
@@ -691,7 +692,18 @@ public class Forwarder extends AbstractForwarder {
                     LOG.isTraceEnabled() ? new NullPointerException("connection") : null);
             return;
         }
-        conn.close();
+        /* Vertx API seems not to have any way to do what we need (eg `shutdown(req, SHUT_WR)`)
+         * So we have to use this less accurate alternative, which is similar to a
+         * `shutdown(req, SHUT_RDWR)`, but it will await pending data on the
+         * current request-response cycle (or up to the timeout) before doing so.
+         * Not exactly what we wanted, but hopefully "good enough".
+         * The other alternative (just calling `close()`) is also a bad option,
+         * as it causes undesired effects like
+         * https://jira.post.ch/browse/MSOP-6438
+         * under edge-case conditions.  */
+        conn.shutdown(300, SECONDS).onFailure((Throwable ex) -> {
+            LOG.info("{}", ex, LOG.isDebugEnabled() ? ex : null);
+        });
     }
 
     /**


### PR DESCRIPTION
Try to approach `shutdown(req, SHUT_WR)` better with `HttpConnection.shutdown()`. As `HttpConnection.close()` causes undesired race-conditions in some edge-cases. Namely an upstream server sending a `Connection: close` header with a response where the response body is split over several tcp fragments. This occasionly CAN cause that the upstream response gets cut in half in between some fragments due to the close cut off the incoming stream too early. Which then when combinded with a `Content-Length` response, will cause our downstream client to hang as he never will receive enough bytes in the response.

## Behavior before patch
<img width="882" height="316" alt="image" src="https://github.com/user-attachments/assets/98eda3be-ae77-4f0d-9f8e-778c31d51b4f" />

## Behavior after patch
<img width="938" height="499" alt="image" src="https://github.com/user-attachments/assets/3533a89e-fd5e-46ce-9f4a-651fba002a05" />

## Reproducer
1st start a gateleen (*I did via PaISA/eagle*) In one shell use `node reproducer.js --zaphod` which will play the upstream server role. Then in a 2nd shell run `node reproducer.js --slarti` which will perform the client request.

`reproducer.js.gz.b64`:
```
H4sIAAAAAAAAA+1YX3PbNhJ/lj/Fhg8tFUuUlEzGGel8M4zt1O7FVlo5TeeaTocmIYkJBbAEaMVx9d1vFwBFkFQyfezDJWMNif2L
xe5vF5z5y5LHKhXc7z8eHR3FgksFCxF/YgpOoWB/lmnBfI8z5fUDsz6zXHHBIsUWrLhnRZfXpVYSa6XyBqdI2JQWvX7Fwj6nZDgv
RMykDOi1IkmVsKJwiGZhdjQaGYYVUzdie5HH62uJbOdoP+BiO9vvKxMrXH/cFqli0/3GN3KFe++lSx+e4HPAeCLfp2rtex+414c+
qHUhtnBRFKLwvUhKVii/wfj9B/59v0+b6DV9C7Qpn7Ot9sbvB0pcLeYLVaR85ffh2IMheMdALsyOdjtytfILt5lydcmynI7GVSxK
ZRV73lGvh0oAPbVPt/Pz+R8vz6/C8OJlFoavPs7DMIT3xH7Narb6aTj8EuVrkdQr9G+hokLhzhmUuVR4lhuQ5qS36zReQ55FDxKM
ZHBYrcxQRdpUey4gAkPQacCkakpTGNwg2HDDfZQNKEywPypcaZ/NPpK9gqmy4CTV0ieZ+q92+lKITz5Eea41jkakUxUls689zJUq
yO/Dn2+mUItBksroLmOJ8Ze4jT39vDvqoYbefVRAHqk1Jpw3MnEa/bFGaTkq8ACZN7NMGAbkoSoIbER8ku+thVTTav/oZ0AL/QGR
clE0SbRgSBum0NIUvLfvbj3DjE5MtSv6dc0izEw5hd/oreddolZv0LGDqTnFcB600fPOBFeMq+HtQ85Q2EN6lsYRRXj0UQru1Xyc
6cATV5wJySrSr8OLzzmiwDBcKlYQeXJiaL/T724Agv/MZI6FyyjIGOI/A6xWj9FZe4asw6UPf8+CRen/uJjfYKFQkaXLBxNOz0RG
erhzbaHnJSiccu01rnp0BNPRaPLsJBjj/0lr/zbXdRgwOvZMtcu7Ppnf7ZOs9tyHQpoM00mLL+hXpEp5htAHT07h2XhsyG7CXd7e
vh2hdWInr37BAyO9WCN21VFSYYhOtmPP5mQP07CXiCsVrqKUv0HwKfyuk3X8fERe44jjx+soxSwHJTBJV6lEHUAZPCVz7DNimQNk
ld1v2mwTyR5W5G26YVgTfqM4B3AyHo8HVKJaSbOOBUdOkVzxWGzQBbsVXdADkNin9GaovvjrIlptMFupJ4xnZhFj+EokD1SckUyW
///75/x59ojidck/Lb7QvGAOK8gYX2GOj+D5rMZY6gmn8K0Oa1LqmnJCUtNapxp76zwnFXUCO/m4fDvZYh/d/hiG5y/ercJwAC+a
Cd3hsDmNxtwWjd1N1/QkGOuKn//nQ2HaHlJqkJyChsgmTQPtG731qS1/NxroeM2uH/UuRk8BRx/YMlhH94xKmHFZFgxxs6SeY+AJ
Ox5SMwkpdUbs7thTVZyjPDyFZVU3ATwd6cDw5IZ9VlU9tWq7S26hSZehcnZ/3M5hy/LOILiPGGBzwYD8vnS7rJrPRqbfPAdN0gos
ELtB/DdUKIxxkxljOY4pG0FeUuhw9roX2N5wGOLYPLMHtAXpJs+IuMxKuUb2Klw2Wk1ca+58AJOxAWmMPdN2l8kznNNeb5+H4dm7
M51IFsWdZOvytENM+6UOuA9tvdLF0KLkdW3Us5DT7GQ13LvTvP8YZZnYXkbZcp4zPqWpSbfrQ4gc3KVo3MI4+dDRHmTUWbj/lVY7
APeG0titU9hGBx0L7ov6dlNLXd47+mkOgabBtCOz0ENqMzJknzSbATbQbcZgj7kZ+Y9afZsniE2F+4/wlaEOvjLRgY6rBQiWtBv4
nmBC0zZL01ISqchzYgh35RL3Ai1exM4oyDGRfaT3Z7Db16UZm6hR/nCBE2VnprUz63CDWoYTd6qdEJsBpkqLGWDspAIWEicOgF3q
+DQHr2/No034c5H0ExbxMMrSexdOfx1SCqcxm9pLiHZ70kbQVns44HtVXu2QGwnaPMb8xTjG3kANIhz/gL+t1tEmd6u5cU+izN7i
wEy47qD8KiV4x3uarVWJqAUq3TAzthHOJxV+143txSu0GuY/4QXx1fVP1Nie47DVdrDFZBzcI2TKlylHR7OHAXwspUZKirr2Jt4f
BehDsKjY2B3y+pOT/qHG2/VvclI52ClVB7rq9EilKXE4PT01F7u//oIOYRll5nrRkDS1f0DSIewlqZ009OooNbG1mmEJ7qEWsOoq
AQdyXIFWVlzczG8X795WUaMvJP7kQGA2OGbrEzPfPihEpzC/+4ingsgbZfpaZPDI29959HXGgNHJePKM3qp9Tc2WzZJx1VmSdqFt
QDegKfAyywbVK4FNdQvb6SvlF2uhI1258nJspHWO1+q0tMYqwpyoWN07n4foFSlLutwQOQ2ROIEZPfxLM1ftfwbHx7jYr2ZKpCEr
cfyWhr9XMwPJk4LvvgNEPbSSlDEbBYruHcjbtxMEhhtvlSWbwehpuuKioPJMJZYv0yXgJAGZQYwcDtcsyz0r73z2mcH+u8JBMXsF
tYLN5NaZ+zVBc1pNwSq3m4LmDN2PWd7F1c0v4RuD0oU7OTu5qAeXA7WBseum/mH1ZxHnQsEdgzuBZySW1XejCAHN7Bwi84lKRhbz
gkNVYT4Xtd148nf9uKZLNloXOY7HprJSKXHUOGyM8KieKEwR0me9nU/jz/8AT/xg9HAVAAA=
```