### PR TITLE
MSOP-7527 fixed the applyQueueConfig may fail if we have duplicated header

### DIFF
--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -1747,7 +1747,7 @@ public class HookHandler implements LoggableResource {
         // try to find X_QUEUE_CONFIG_NAME_PATTERN and X_QUEUE_CONFIG_MAX_LIMIT headers
         for (Object obj : headers) {
             if (!(obj instanceof JsonObject)) {
-                log.info("Ignoring invalid header config entry: {}", obj);
+                log.debug("Ignoring invalid header for per queue config entry: {}", obj);
                 continue;
             }
             JsonObject headerPair = (JsonObject) obj;

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -1732,28 +1732,63 @@ public class HookHandler implements LoggableResource {
         }
     }
 
-    private void applyQueueConfig(JsonArray headers) {
-        if (headers != null) {
-            Map<String, String> headerMap = headers.stream()
-                    .map(obj -> (JsonObject) obj)
-                    .collect(Collectors.toMap(
-                            h -> h.getString("header"),
-                            h -> h.getString("value")
-                    ));
-            if (headerMap.containsKey(X_QUEUE_CONFIG_NAME_PATTERN) && headerMap.containsKey(X_QUEUE_CONFIG_MAX_LIMIT)) {
-                final String queueFilter = headerMap.getOrDefault(X_QUEUE_CONFIG_NAME_PATTERN, "");
-                JsonObject jsonObject = new JsonObject();
-                jsonObject.put(RedisquesAPI.PER_QUEUE_CONFIG_MAX_QUEUE_ENTRIES, Long.parseLong(headerMap.getOrDefault(X_QUEUE_CONFIG_MAX_LIMIT, "0")));
-                requestQueue.setPerQueueConfig(queueFilter, jsonObject).onComplete(event -> {
-                    if (event.failed()) {
-                        log.error("faile to apply queue config for {}", queueFilter);
-                    } else {
-                        log.debug("applied queue config for {}", queueFilter);
-                    }
-                });
+    /**
+     * find the special headers {@link #X_QUEUE_CONFIG_NAME_PATTERN} and {@link #X_QUEUE_CONFIG_MAX_LIMIT} in the headermap and apply to queue by RedisQues-API
+     * @param headers
+     */
+    void applyQueueConfig(JsonArray headers) {
+        if (headers == null) {
+            return;
+        }
+
+        String queueNamePattern = null;
+        String maxLimitRaw = null;
+
+        // try to find X_QUEUE_CONFIG_NAME_PATTERN and X_QUEUE_CONFIG_MAX_LIMIT headers
+        for (Object obj : headers) {
+            if (!(obj instanceof JsonObject)) {
+                log.warn("Ignoring invalid header config entry: {}", obj);
+                continue;
+            }
+            JsonObject headerPair = (JsonObject) obj;
+            String name = headerPair.getString("header");
+            String value = headerPair.getString("value");
+
+            if (X_QUEUE_CONFIG_NAME_PATTERN.equals(name)) {
+                queueNamePattern = value;
+            } else if (X_QUEUE_CONFIG_MAX_LIMIT.equals(name)) {
+                maxLimitRaw = value;
             }
         }
 
+        if (queueNamePattern == null || maxLimitRaw == null) {
+            return;
+        }
+
+        final long maxLimit;
+        try {
+            maxLimit = Long.parseLong(maxLimitRaw);
+        } catch (NumberFormatException e) {
+            log.warn("Invalid max queue limit value: {}", maxLimitRaw);
+            return;
+        }
+
+        if (maxLimit < 0) {
+            log.warn("Invalid negative queue max limit: {}", maxLimit);
+            return;
+        }
+
+        JsonObject maxLimitConfig = new JsonObject()
+                .put(RedisquesAPI.PER_QUEUE_CONFIG_MAX_QUEUE_ENTRIES, maxLimit);
+
+        final String finalQueueNamePattern = queueNamePattern;
+        requestQueue.setPerQueueConfig(queueNamePattern, maxLimitConfig).onComplete(ar -> {
+            if (ar.failed()) {
+                log.error("Failed to apply queue config for {}", finalQueueNamePattern, ar.cause());
+            } else {
+                log.debug("Applied queue config for {}", finalQueueNamePattern);
+            }
+        });
     }
 
     /**

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -1747,7 +1747,7 @@ public class HookHandler implements LoggableResource {
         // try to find X_QUEUE_CONFIG_NAME_PATTERN and X_QUEUE_CONFIG_MAX_LIMIT headers
         for (Object obj : headers) {
             if (!(obj instanceof JsonObject)) {
-                log.warn("Ignoring invalid header config entry: {}", obj);
+                log.info("Ignoring invalid header config entry: {}", obj);
                 continue;
             }
             JsonObject headerPair = (JsonObject) obj;

--- a/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
+++ b/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
@@ -29,6 +29,7 @@ import org.swisspush.gateleen.monitoring.MonitoringHandler;
 import org.swisspush.gateleen.core.util.ExpiryCheckHandler;
 import org.swisspush.gateleen.queue.queuing.RequestQueue;
 import org.swisspush.gateleen.routing.Router;
+import org.swisspush.redisques.util.RedisquesAPI;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -982,6 +983,131 @@ public class HookHandlerTest {
         testContext.assertTrue(result);
         String jsonResponse = responseCaptor.getValue();
         assertEmptyResult(jsonResponse);
+    }
+
+    @Test
+    public void testApplyQueueConfigWithDuplicateHeaders() {
+        JsonArray headers = new JsonArray()
+                .add(new JsonObject().put("header", "x-queue-config-name-pattern").put("value", "q.*"))
+                .add(new JsonObject().put("header", "x-queue-config-name-pattern").put("value", "q2.*"))
+                .add(new JsonObject().put("header", "x-queue-config-max-limit").put("value", "100"));
+        when(requestQueue.setPerQueueConfig(eq("q2.*"), any(JsonObject.class))).thenReturn(Future.succeededFuture());
+        hookHandler.applyQueueConfig(headers);
+    }
+    @Test
+    public void testApplyQueueConfigWithNonJsonObjectHeader() {
+        JsonArray headers = new JsonArray()
+                .add("bad-entry")
+                .add(new JsonObject().put("header", "x-queue-config-max-limit").put("value", "100"));
+
+        hookHandler.applyQueueConfig(headers);
+    }
+    @Test
+    public void testApplyQueueConfigWithInvalidMaxLimit() {
+        JsonArray headers = new JsonArray()
+                .add(new JsonObject().put("header", "x-queue-config-name-pattern").put("value", "q.*"))
+                .add(new JsonObject().put("header", "x-queue-config-max-limit").put("value", "abc"));
+
+        hookHandler.applyQueueConfig(headers);
+    }
+    @Test
+    public void testApplyQueueConfigWithNullValue() {
+        JsonArray headers = new JsonArray()
+                .add(new JsonObject().put("header", "x-queue-config-name-pattern").put("value", "q.*"))
+                .add(new JsonObject().put("header", "x-queue-config-max-limit"));
+
+        hookHandler.applyQueueConfig(headers);
+    }
+
+    @Test
+    public void testApplyQueueConfigWithValidHeadersShouldSetPerQueueConfig() {
+        JsonArray headers = new JsonArray()
+                .add(new JsonObject()
+                        .put("header", "x-queue-config-name-pattern")
+                        .put("value", "queue.*"))
+                .add(new JsonObject()
+                        .put("header", "x-queue-config-max-limit")
+                        .put("value", "100"));
+        when(requestQueue.setPerQueueConfig(any(), any(JsonObject.class))).thenReturn(Future.succeededFuture());
+        hookHandler.applyQueueConfig(headers);
+
+        verify(requestQueue).setPerQueueConfig(
+                eq("queue.*"),
+                argThat(cfg ->
+                        cfg.getLong(RedisquesAPI.PER_QUEUE_CONFIG_MAX_QUEUE_ENTRIES) == 100L)
+        );
+    }
+    
+    @Test
+    public void testApplyQueueConfigWithUnrelatedHeadersShouldIgnoreThem() {
+        JsonArray headers = new JsonArray()
+                .add(new JsonObject()
+                        .put("header", "content-type")
+                        .put("value", "application/json"))
+                .add(new JsonObject()
+                        .put("header", "x-queue-config-name-pattern")
+                        .put("value", "queue.*"))
+                .add(new JsonObject()
+                        .put("header", "x-queue-config-max-limit")
+                        .put("value", "200"));
+        when(requestQueue.setPerQueueConfig(any(), any(JsonObject.class))).thenReturn(Future.succeededFuture());
+        hookHandler.applyQueueConfig(headers);
+
+        verify(requestQueue).setPerQueueConfig(
+                eq("queue.*"),
+                argThat(cfg ->
+                        cfg.getLong(RedisquesAPI.PER_QUEUE_CONFIG_MAX_QUEUE_ENTRIES) == 200L)
+        );
+    }
+    
+    @Test
+    public void testApplyQueueConfigWithoutQueueConfigHeadersShouldNotSetConfig() {
+        JsonArray headers = new JsonArray()
+                .add(new JsonObject()
+                        .put("header", "content-type")
+                        .put("value", "application/json"));
+
+        hookHandler.applyQueueConfig(headers);
+
+        verify(requestQueue, never()).setPerQueueConfig(anyString(), any(JsonObject.class));
+    }
+    
+    @Test
+    public void testApplyQueueConfigWithOnlyNamePatternShouldNotSetConfig() {
+        JsonArray headers = new JsonArray()
+                .add(new JsonObject()
+                        .put("header", "x-queue-config-name-pattern")
+                        .put("value", "queue.*"));
+
+        hookHandler.applyQueueConfig(headers);
+
+        verify(requestQueue, never()).setPerQueueConfig(anyString(), any(JsonObject.class));
+    }
+    
+    @Test
+    public void testApplyQueueConfigWithOnlyMaxLimitShouldNotSetConfig() {
+        JsonArray headers = new JsonArray()
+                .add(new JsonObject()
+                        .put("header", "x-queue-config-max-limit")
+                        .put("value", "100"));
+
+        hookHandler.applyQueueConfig(headers);
+        verify(requestQueue, never()).setPerQueueConfig(anyString(), any(JsonObject.class));
+    }
+
+    @Test
+    public void testApplyQueueConfigWithDifferentCaseHeadersShouldNotSetConfig() {
+        JsonArray headers = new JsonArray()
+                .add(new JsonObject()
+                        .put("header", "X-Queue-Config-Name-Pattern")
+                        .put("value", "queue.*"))
+                .add(new JsonObject()
+                        .put("header", "X-Queue-Config-Max-Limit")
+                        .put("value", "100"));
+
+        hookHandler.applyQueueConfig(headers);
+
+        verify(requestQueue, never()).setPerQueueConfig(anyString(), any(JsonObject.class));
     }
 
     ///////////////////////////////////////////////////////////////////////////////

--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueueClient.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueueClient.java
@@ -187,12 +187,6 @@ public class QueueClient implements RequestQueue {
         return promise.future();
     }
 
-    /**
-     * appy custom config to queue matchs the pattern
-     *
-     * @param filterPattern pattern to filter the queue
-     * @param config a set of config will apply to queues match the pattern
-     */
     @Override
     public Future<Void> setPerQueueConfig(String filterPattern, JsonObject config) {
         Promise<Void> promise = Promise.promise();

--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/RequestQueue.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/RequestQueue.java
@@ -28,5 +28,11 @@ public interface RequestQueue {
 
     Future<Void> enqueueFuture(HttpRequest queuedRequest, String queue);
 
-    Future<Void> setPerQueueConfig(String queue, JsonObject config);
+    /**
+     * appy custom config to queue matchs the pattern
+     *
+     * @param filterPattern pattern to filter the queue
+     * @param config a set of config will apply to queues match the pattern
+     */
+    Future<Void> setPerQueueConfig(String filterPattern, JsonObject config);
 }


### PR DESCRIPTION
- fixed applyQueueConfig function that failed if we have duplicated header
- move function comment into interface
- added more tests to convers the almost use case
