### PR TITLE
Sdcisa 15631 fixed possible memory leak

### DIFF
--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/splitter/QueueSplitterImpl.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/splitter/QueueSplitterImpl.java
@@ -1,6 +1,8 @@
 package org.swisspush.gateleen.queue.queuing.splitter;
 
 import com.google.common.base.Strings;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
@@ -14,6 +16,7 @@ import org.swisspush.gateleen.queue.queuing.splitter.executors.QueueSplitExecuto
 import org.swisspush.gateleen.queue.queuing.splitter.executors.QueueSplitExecutorFromStaticList;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -23,12 +26,12 @@ import static org.swisspush.gateleen.queue.queuing.splitter.QueueSplitterConfigu
 public class QueueSplitterImpl extends ConfigurationResourceConsumer implements QueueSplitter {
 
     public static final String NUMBER_OF_STATIC_QUEUES = "x-static-queue-count";
+    public static final int DYNAMIC_QUEUES_EXPIRE_TIME_DAYS = 24;
     private final Logger log = LoggerFactory.getLogger(QueueSplitterImpl.class);
 
     private final Map<String, Object> properties;
-
     private List<QueueSplitExecutor> configurableQueueSplitExecutors = new ArrayList<>();
-    private Map<String, QueueSplitExecutorFromStaticList> dynamicQueueSplitExecutors = new HashMap<>();
+    private final Cache<String, QueueSplitExecutorFromStaticList> dynamicQueueSplitExecutors;
 
     public QueueSplitterImpl(
             ConfigurationResourceManager configurationResourceManager,
@@ -44,6 +47,10 @@ public class QueueSplitterImpl extends ConfigurationResourceConsumer implements 
     ) {
         super(configurationResourceManager, configResourceUri, "gateleen_queue_splitter_configuration_schema");
         this.properties = properties;
+        dynamicQueueSplitExecutors = CacheBuilder.newBuilder()
+                .expireAfterAccess(DYNAMIC_QUEUES_EXPIRE_TIME_DAYS, TimeUnit.HOURS)
+                .build();
+
     }
 
     public Future<Void> initialize() {
@@ -82,38 +89,42 @@ public class QueueSplitterImpl extends ConfigurationResourceConsumer implements 
     private String dynamicSplitProcessing(String queueName, HttpServerRequest request) {
 
         final String numberOfQueueString = request.headers() == null ? null : request.headers().get(NUMBER_OF_STATIC_QUEUES);
-        if (Strings.isNullOrEmpty(numberOfQueueString)) {
+        final QueueSplitExecutorFromStaticList existDynamicQueueSplitExecutor = dynamicQueueSplitExecutors.getIfPresent(queueName);
+
+        if (Strings.isNullOrEmpty(numberOfQueueString) && existDynamicQueueSplitExecutor == null) {
             // do nothing
             return queueName;
         }
 
-        int numberOfQueue;
+        // take the numberOfQueue from exist executor, if there is one.
+        int numberOfQueue = existDynamicQueueSplitExecutor == null ? 0 : existDynamicQueueSplitExecutor.getConfiguration().getPostfixFromStatic().size();
         try {
             numberOfQueue = Integer.parseInt(numberOfQueueString);
         } catch (NumberFormatException ex) {
             log.error("can not parsing number of queue from {}", numberOfQueueString, log.isDebugEnabled() ? ex : null);
-            return queueName;
+            if (existDynamicQueueSplitExecutor == null) {
+                return queueName;
+            }
         }
 
         // split a queue into ONE group, there is meaningless
         if (numberOfQueue <= 1) {
             log.warn("number of queue {} is less than 2, queue split will not enable, exist queue split will disable", queueName);
-            dynamicQueueSplitExecutors.remove(queueName);
+            dynamicQueueSplitExecutors.invalidate(queueName);
             return queueName;
         }
 
-        QueueSplitExecutorFromStaticList dynamicQueueSplitExecutor = null;
+        QueueSplitExecutorFromStaticList dynamicQueueSplitExecutor;
         // do we have existed split executor, create if missing
-        if (dynamicQueueSplitExecutors.containsKey(queueName)) {
-            QueueSplitExecutorFromStaticList existDynamicQueueSplitExecutor = dynamicQueueSplitExecutors.get(queueName);
+        if (existDynamicQueueSplitExecutor != null) {
             int existConfigSize = existDynamicQueueSplitExecutor.getConfiguration().getPostfixFromStatic() == null ? 0 : existDynamicQueueSplitExecutor.getConfiguration().getPostfixFromStatic().size();
+            dynamicQueueSplitExecutor = existDynamicQueueSplitExecutor;
             if (existConfigSize != numberOfQueue) {
                 // queue split config changed, will update
                 log.debug("{} already exists in queue, will update, number of queue change from {} to {}", queueName, existConfigSize, numberOfQueue);
-                existDynamicQueueSplitExecutor = createDynamicQueueSplitExecutor(queueName, numberOfQueue);
-                dynamicQueueSplitExecutors.put(queueName, existDynamicQueueSplitExecutor);
+                dynamicQueueSplitExecutor = createDynamicQueueSplitExecutor(queueName, numberOfQueue);
+                dynamicQueueSplitExecutors.put(queueName, dynamicQueueSplitExecutor);
             }
-            dynamicQueueSplitExecutor = existDynamicQueueSplitExecutor;
         } else {
             log.info("create new queue split executor for queue '{}'", queueName);
             dynamicQueueSplitExecutor = createDynamicQueueSplitExecutor(queueName, numberOfQueue);
@@ -162,5 +173,6 @@ public class QueueSplitterImpl extends ConfigurationResourceConsumer implements 
             log.info("Queue splitter configuration resource {} was removed. Going to release all executors", resourceUri);
             configurableQueueSplitExecutors.clear();
         }
+        dynamicQueueSplitExecutors.invalidateAll();
     }
 }

--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/splitter/QueueSplitterImpl.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/splitter/QueueSplitterImpl.java
@@ -26,7 +26,7 @@ import static org.swisspush.gateleen.queue.queuing.splitter.QueueSplitterConfigu
 public class QueueSplitterImpl extends ConfigurationResourceConsumer implements QueueSplitter {
 
     public static final String NUMBER_OF_STATIC_QUEUES = "x-static-queue-count";
-    public static final int DYNAMIC_QUEUES_EXPIRE_TIME_DAYS = 24;
+    public static final int DYNAMIC_QUEUES_EXPIRE_TIME_HOURS = 24;
     private final Logger log = LoggerFactory.getLogger(QueueSplitterImpl.class);
 
     private final Map<String, Object> properties;
@@ -48,7 +48,7 @@ public class QueueSplitterImpl extends ConfigurationResourceConsumer implements 
         super(configurationResourceManager, configResourceUri, "gateleen_queue_splitter_configuration_schema");
         this.properties = properties;
         dynamicQueueSplitExecutors = CacheBuilder.newBuilder()
-                .expireAfterAccess(DYNAMIC_QUEUES_EXPIRE_TIME_DAYS, TimeUnit.HOURS)
+                .expireAfterAccess(DYNAMIC_QUEUES_EXPIRE_TIME_HOURS, TimeUnit.HOURS)
                 .build();
 
     }

--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/splitter/QueueSplitterImpl.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/splitter/QueueSplitterImpl.java
@@ -97,7 +97,9 @@ public class QueueSplitterImpl extends ConfigurationResourceConsumer implements 
         }
 
         // take the numberOfQueue from exist executor, if there is one.
-        int numberOfQueue = existDynamicQueueSplitExecutor == null ? 0 : existDynamicQueueSplitExecutor.getConfiguration().getPostfixFromStatic().size();
+        int numberOfQueue = existDynamicQueueSplitExecutor == null ? 0 :
+                existDynamicQueueSplitExecutor.getConfiguration().getPostfixFromStatic() == null ? 0 :
+                existDynamicQueueSplitExecutor.getConfiguration().getPostfixFromStatic().size();
         try {
             numberOfQueue = Integer.parseInt(numberOfQueueString);
         } catch (NumberFormatException ex) {

--- a/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/queuing/splitter/QueueSplitterImplTest.java
+++ b/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/queuing/splitter/QueueSplitterImplTest.java
@@ -197,6 +197,82 @@ public class QueueSplitterImplTest {
         });
     }
 
+    @Test
+    public void resourceRemovedShouldAlsoCleanTheDynamicQueueSplit(TestContext context) {
+
+        // Given
+        Async async = context.async();
+        storage.putMockData(configResourceUri, CONFIG_RESOURCE_VALID_1);
+
+        // When
+        queueSplitter.initialize().onComplete(event -> {
+
+            // Then
+            verifySplitWithDynamicExecuted(context);
+            // When
+            queueSplitter.resourceRemoved(configResourceUri);
+            // Then
+            verifySplitWithDynamicNotExecutedWithoutHeader(context);
+            async.complete();
+        });
+    }
+
+    @Test
+    public void dynamicQueueSplitHeaderControl(TestContext context) {
+
+        // Given
+        Async async = context.async();
+        storage.putMockData(configResourceUri, CONFIG_RESOURCE_VALID_1);
+
+        // When
+        queueSplitter.initialize().onComplete(event -> {
+            HttpServerRequest request = mock(HttpServerRequest.class);
+
+            //turn ON
+            when(request.headers()).thenReturn(new HeadersMultiMap().add(NUMBER_OF_STATIC_QUEUES, "3"));
+            context.assertEquals("my-other-queue-1-Q1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1-Q2", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1-Q3", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1-Q1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+
+            //turn OFF by set to 0
+            when(request.headers()).thenReturn(new HeadersMultiMap().add(NUMBER_OF_STATIC_QUEUES, "0"));
+            context.assertEquals("my-other-queue-1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+
+            //turn ON Again
+            when(request.headers()).thenReturn(new HeadersMultiMap().add(NUMBER_OF_STATIC_QUEUES, "2"));
+            context.assertEquals("my-other-queue-1-Q1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1-Q2", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1-Q1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1-Q2", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+
+            // Empty header
+            when(request.headers()).thenReturn(new HeadersMultiMap());
+            context.assertEquals("my-other-queue-1-Q1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1-Q2", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1-Q1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1-Q2", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+
+            //Wrong header
+            when(request.headers()).thenReturn(new HeadersMultiMap().add(NUMBER_OF_STATIC_QUEUES, "X"));
+            context.assertEquals("my-other-queue-1-Q1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1-Q2", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1-Q1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1-Q2", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+
+            //turn OFF by set to 1
+            when(request.headers()).thenReturn(new HeadersMultiMap().add(NUMBER_OF_STATIC_QUEUES, "1"));
+            context.assertEquals("my-other-queue-1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+
+            // Empty header, remain OfFF
+            when(request.headers()).thenReturn(new HeadersMultiMap());
+            context.assertEquals("my-other-queue-1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            context.assertEquals("my-other-queue-1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+            async.complete();
+        });
+    }
 
     private void verifySplitStaticExecuted(TestContext context) {
         HttpServerRequest request = mock(HttpServerRequest.class);
@@ -243,6 +319,13 @@ public class QueueSplitterImplTest {
         when(request.headers()).thenReturn(new HeadersMultiMap().add(NUMBER_OF_STATIC_QUEUES, "Not A Number"));
         context.assertEquals("my-other-queue-1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
         when(request.headers()).thenReturn(new HeadersMultiMap().add(NUMBER_OF_STATIC_QUEUES, "1"));
+        context.assertEquals("my-other-queue-1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+    }
+
+    private void verifySplitWithDynamicNotExecutedWithoutHeader(TestContext context) {
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        context.assertEquals("my-other-queue-1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
+        context.assertEquals("my-other-queue-1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
         context.assertEquals("my-other-queue-1", queueSplitter.convertToSubQueue("my-other-queue-1", request));
     }
 


### PR DESCRIPTION
fixed possible memory leak:
- use cache to expires a QueueSplitExecutor in case long time not in use
- removed all Dynamic QueueSplitExecutors when config resource removed
- fixed the wrong header will skip the QueueSplitExecutor exist check
- more tests....