### PR TITLE
SDCISA-23097 check and drop expired queue before enqueue it

### DIFF
--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/ExpiryCheckHandler.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/util/ExpiryCheckHandler.java
@@ -24,6 +24,7 @@ import java.util.Optional;
  */
 public final class ExpiryCheckHandler {
     public static final String SERVER_TIMESTAMP_HEADER = "X-Server-Timestamp";
+    public static final String CLIENT_TIMESTAMP_HEADER = "X-Client-Timestamp";
     public static final String EXPIRE_AFTER_HEADER = "X-Expire-After";
     public static final String QUEUE_EXPIRE_AFTER_HEADER = "x-queue-expire-after";
 

--- a/gateleen-packing/README_packing.md
+++ b/gateleen-packing/README_packing.md
@@ -57,6 +57,15 @@ The defined requests will be enqueued using the configured queueName prefix and 
 x-queue: <queueName>
 ```
 
+## Expired packed requests
+Packed sub-requests carrying `X-Client-Timestamp` are checked for expiry using `x-queue-expire-after` (or fallback `X-Expire-After`) in the same way as queueing requests.
+
+When `PackingHandler` is configured with `enqueueExpiredRequest = false`, expired packed sub-requests are dropped and not enqueued.
+
+If all packed sub-requests in one packed request are dropped as expired, the HTTP response status defaults to `202 Accepted`. This can be overridden via the constructor overload parameter `StatusCode expiredRequestStatusCode`.
+
+If at least one packed sub-request is still enqueued, the packed request response remains `200 OK`.
+
 ## Micrometer metrics
 The packing feature is monitored with micrometer. The following metrics are available:
 * gateleen_packing_requests_success_total

--- a/gateleen-packing/README_packing.md
+++ b/gateleen-packing/README_packing.md
@@ -61,6 +61,7 @@ x-queue: <queueName>
 The packing feature is monitored with micrometer. The following metrics are available:
 * gateleen_packing_requests_success_total
 * gateleen_packing_requests_fail_total
+* gateleen_packing_requests_drop_total
 
 Example metrics:
 
@@ -71,6 +72,9 @@ gateleen_packing_requests_success_total 8234.0
 # HELP gateleen_packing_requests_fail_total Amount of failed packed requests processed
 # TYPE gateleen_packing_requests_fail_total counter
 gateleen_packing_requests_fail_total 0.0
+# HELP gateleen_packing_requests_drop_total Amount of dropped (expired) packed requests processed
+# TYPE gateleen_packing_requests_drop_total counter
+gateleen_packing_requests_drop_total 0.0
 ```
 
 To enable `gateleen_kafka_send_success_messages_total` and `gateleen_kafka_send_fail_messages_total` metrics, set a `MeterRegistry` instance by calling `setMeterRegistry(MeterRegistry meterRegistry)` method in `KafkaMessageSender` class.

--- a/gateleen-packing/README_packing.md
+++ b/gateleen-packing/README_packing.md
@@ -65,6 +65,7 @@ When `PackingHandler` is configured with `enqueueExpiredRequest = false`, expire
 If all packed sub-requests in one packed request are dropped as expired, the HTTP response status defaults to `202 Accepted`. This can be overridden via the constructor overload parameter `StatusCode expiredRequestStatusCode`.
 
 If at least one packed sub-request is still enqueued, the packed request response remains `200 OK`.
+This status is an acceptance of packed request processing; actual sub-request enqueues complete asynchronously.
 
 ## Micrometer metrics
 The packing feature is monitored with micrometer. The following metrics are available:

--- a/gateleen-packing/src/main/java/org/swisspush/gateleen/packing/PackingHandler.java
+++ b/gateleen-packing/src/main/java/org/swisspush/gateleen/packing/PackingHandler.java
@@ -45,11 +45,14 @@ public class PackingHandler {
     private MeterRegistry meterRegistry;
     private Counter packingRequestsSuccessCounter;
     private Counter packingRequestsFailCounter;
+    private Counter packingRequestsDropCounter;
 
     public static final String PACKING_REQUESTS_SUCCESS_COUNTER = "gateleen.packing.requests.success";
     public static final String PACKING_REQUESTS_SUCCESS_COUNTER_DESCRIPTION = "Amount of successfully packed requests processed";
     public static final String PACKING_REQUESTS_FAIL_COUNTER = "gateleen.packing.requests.fail";
     public static final String PACKING_REQUESTS_FAIL_COUNTER_DESCRIPTION = "Amount of failed packed requests processed";
+    public static final String PACKING_REQUESTS_DROP_COUNTER = "gateleen.packing.requests.drop";
+    public static final String PACKING_REQUESTS_DROP_COUNTER_DESCRIPTION = "Amount of dropped (expired) packed requests processed";
 
     /**
      * Constructs a new PackingHandler.
@@ -73,7 +76,7 @@ public class PackingHandler {
     }
 
     public PackingHandler(Vertx vertx, String queuePrefix, String redisquesAddress, String groupRequestHeader, PackingValidator validator, GateleenExceptionFactory exceptionFactory) {
-        this(vertx, queuePrefix, redisquesAddress, groupRequestHeader, validator, exceptionFactory, false);
+        this(vertx, queuePrefix, redisquesAddress, groupRequestHeader, validator, exceptionFactory, true);
     }
 
     public boolean isPacked(HttpServerRequest request) {
@@ -93,9 +96,13 @@ public class PackingHandler {
             packingRequestsFailCounter = Counter.builder(PACKING_REQUESTS_FAIL_COUNTER)
                     .description(PACKING_REQUESTS_FAIL_COUNTER_DESCRIPTION)
                     .register(meterRegistry);
+            packingRequestsDropCounter = Counter.builder(PACKING_REQUESTS_DROP_COUNTER)
+                    .description(PACKING_REQUESTS_DROP_COUNTER_DESCRIPTION)
+                    .register(meterRegistry);
         } else {
             packingRequestsSuccessCounter = null;
             packingRequestsFailCounter = null;
+            packingRequestsDropCounter = null;
         }
     }
 
@@ -139,6 +146,7 @@ public class PackingHandler {
 
                 if (!enqueueExpiredRequest && QueuingHandler.isRequestExpired(req.getHeaders())) {
                     requestLog.info("Dropping expired packed request '{}'", req.getUri());
+                    incrementDropCounter();
                     continue;
                 }
 
@@ -193,6 +201,12 @@ public class PackingHandler {
     private void incrementFailCounter() {
         if(packingRequestsFailCounter != null) {
             packingRequestsFailCounter.increment();
+        }
+    }
+
+    private void incrementDropCounter() {
+        if(packingRequestsDropCounter != null) {
+            packingRequestsDropCounter.increment();
         }
     }
 }

--- a/gateleen-packing/src/main/java/org/swisspush/gateleen/packing/PackingHandler.java
+++ b/gateleen-packing/src/main/java/org/swisspush/gateleen/packing/PackingHandler.java
@@ -41,6 +41,7 @@ public class PackingHandler {
     private final String queuePrefix;
     private final PackingValidator validator;
     private final GateleenExceptionFactory exceptionFactory;
+    private final boolean enqueueExpiredRequest;
     private MeterRegistry meterRegistry;
     private Counter packingRequestsSuccessCounter;
     private Counter packingRequestsFailCounter;
@@ -59,14 +60,20 @@ public class PackingHandler {
      * @param groupRequestHeader the header holding the user group information
      * @param validator the PackingValidator instance
      * @param exceptionFactory the GateleenExceptionFactory instance
+     * @param enqueueExpiredRequest enqueue the request which already expired
      */
-    public PackingHandler(Vertx vertx, String queuePrefix, String redisquesAddress, String groupRequestHeader, PackingValidator validator, GateleenExceptionFactory exceptionFactory) {
+    public PackingHandler(Vertx vertx, String queuePrefix, String redisquesAddress, String groupRequestHeader, PackingValidator validator, GateleenExceptionFactory exceptionFactory, boolean enqueueExpiredRequest) {
         this.vertx = vertx;
         this.queuePrefix = queuePrefix;
         this.redisquesAddress = redisquesAddress;
         this.groupRequestHeader = groupRequestHeader;
         this.validator = validator;
         this.exceptionFactory = exceptionFactory;
+        this.enqueueExpiredRequest = enqueueExpiredRequest;
+    }
+
+    public PackingHandler(Vertx vertx, String queuePrefix, String redisquesAddress, String groupRequestHeader, PackingValidator validator, GateleenExceptionFactory exceptionFactory) {
+        this(vertx, queuePrefix, redisquesAddress, groupRequestHeader, validator, exceptionFactory, false);
     }
 
     public boolean isPacked(HttpServerRequest request) {
@@ -128,6 +135,11 @@ public class PackingHandler {
                 if (req.getHeaders() != null) {
                     req.getHeaders().remove(ExpiryCheckHandler.SERVER_TIMESTAMP_HEADER);
                     req.getHeaders().remove(QueuingHandler.QUEUE_HEADER);
+                }
+
+                if (!enqueueExpiredRequest && QueuingHandler.isRequestExpired(req.getHeaders())) {
+                    requestLog.info("Dropping expired packed request '{}'", req.getUri());
+                    continue;
                 }
 
                 ExpiryCheckHandler.updateServerTimestampHeader(req);

--- a/gateleen-packing/src/main/java/org/swisspush/gateleen/packing/PackingHandler.java
+++ b/gateleen-packing/src/main/java/org/swisspush/gateleen/packing/PackingHandler.java
@@ -42,6 +42,7 @@ public class PackingHandler {
     private final PackingValidator validator;
     private final GateleenExceptionFactory exceptionFactory;
     private final boolean enqueueExpiredRequest;
+    private final StatusCode expiredRequestStatusCode;
     private MeterRegistry meterRegistry;
     private Counter packingRequestsSuccessCounter;
     private Counter packingRequestsFailCounter;
@@ -66,6 +67,19 @@ public class PackingHandler {
      * @param enqueueExpiredRequest enqueue the request which already expired
      */
     public PackingHandler(Vertx vertx, String queuePrefix, String redisquesAddress, String groupRequestHeader, PackingValidator validator, GateleenExceptionFactory exceptionFactory, boolean enqueueExpiredRequest) {
+        this(vertx, queuePrefix, redisquesAddress, groupRequestHeader, validator, exceptionFactory, enqueueExpiredRequest, StatusCode.ACCEPTED);
+    }
+
+    public PackingHandler(
+            Vertx vertx,
+            String queuePrefix,
+            String redisquesAddress,
+            String groupRequestHeader,
+            PackingValidator validator,
+            GateleenExceptionFactory exceptionFactory,
+            boolean enqueueExpiredRequest,
+            StatusCode expiredRequestStatusCode
+    ) {
         this.vertx = vertx;
         this.queuePrefix = queuePrefix;
         this.redisquesAddress = redisquesAddress;
@@ -73,6 +87,7 @@ public class PackingHandler {
         this.validator = validator;
         this.exceptionFactory = exceptionFactory;
         this.enqueueExpiredRequest = enqueueExpiredRequest;
+        this.expiredRequestStatusCode = expiredRequestStatusCode == null ? StatusCode.ACCEPTED : expiredRequestStatusCode;
     }
 
     public PackingHandler(Vertx vertx, String queuePrefix, String redisquesAddress, String groupRequestHeader, PackingValidator validator, GateleenExceptionFactory exceptionFactory) {
@@ -136,6 +151,8 @@ public class PackingHandler {
                 return;
             }
 
+            int droppedExpiredRequests = 0;
+            int enqueuedRequests = 0;
             for (HttpRequest req : parseRequestsResult.ok()) {
                 String queueName = getQueueFromRequestOrPrefix(req, fallbackQueueNameSuffix);
 
@@ -147,8 +164,10 @@ public class PackingHandler {
                 if (!enqueueExpiredRequest && QueuingHandler.isRequestExpired(req.getHeaders())) {
                     requestLog.info("Dropping expired packed request '{}'", req.getUri());
                     incrementDropCounter();
+                    droppedExpiredRequests++;
                     continue;
                 }
+                enqueuedRequests++;
 
                 ExpiryCheckHandler.updateServerTimestampHeader(req);
 
@@ -172,7 +191,11 @@ public class PackingHandler {
                 });
             }
 
-            respondWith(request, StatusCode.OK);
+            if (droppedExpiredRequests > 0 && enqueuedRequests == 0) {
+                respondWith(request, expiredRequestStatusCode);
+            } else {
+                respondWith(request, StatusCode.OK);
+            }
         });
 
         return true;

--- a/gateleen-packing/src/main/java/org/swisspush/gateleen/packing/PackingHandler.java
+++ b/gateleen-packing/src/main/java/org/swisspush/gateleen/packing/PackingHandler.java
@@ -191,6 +191,8 @@ public class PackingHandler {
                 });
             }
 
+            // Response reflects synchronous packing validation/drop decisions only.
+            // Actual enqueue operations complete asynchronously via event bus callbacks.
             if (droppedExpiredRequests > 0 && enqueuedRequests == 0) {
                 respondWith(request, expiredRequestStatusCode);
             } else {

--- a/gateleen-packing/src/test/java/org/swisspush/gateleen/packing/PackingHandlerTest.java
+++ b/gateleen-packing/src/test/java/org/swisspush/gateleen/packing/PackingHandlerTest.java
@@ -56,7 +56,7 @@ public class PackingHandlerTest {
         eventBus = Mockito.spy(vertx.eventBus());
         exceptionFactory = mock(GateleenExceptionFactory.class);
         validator = mock(PackingValidator.class);
-        packingHandler = new PackingHandler(vertx, queuePrefix, redisquesAddress, RoleExtractor.groupHeader, validator, exceptionFactory);
+        packingHandler = new PackingHandler(vertx, queuePrefix, redisquesAddress, RoleExtractor.groupHeader, validator, exceptionFactory, false);
 
         meterRegistry = new SimpleMeterRegistry();
         packingHandler.setMeterRegistry(meterRegistry);
@@ -422,6 +422,50 @@ public class PackingHandlerTest {
 
         assertSuccessMetricCounts(context, 0.0);
         assertFailMetricCounts(context, 0.0);
+        assertDropMetricCounts(context, 1.0);
+    }
+
+    @Test
+    public void testHandleEnqueuesExpiredRequestByDefault(TestContext context) {
+        Async async = context.async(1);
+        SimpleMeterRegistry defaultMeterRegistry = new SimpleMeterRegistry();
+        PackingHandler defaultPackingHandler = new PackingHandler(vertx, queuePrefix, redisquesAddress, RoleExtractor.groupHeader, validator, exceptionFactory);
+        defaultPackingHandler.setMeterRegistry(defaultMeterRegistry);
+
+        when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap().add(PACK_HEADER, "true").add("x-rp-grp", "master"));
+        when(request.method()).thenReturn(HttpMethod.PUT);
+        when(validator.validatePackingPayload(any())).thenReturn(new ValidationResult(ValidationStatus.VALIDATED_POSITIV));
+
+        String expiredClientTimestamp = ExpiryCheckHandler.printDateTime(DateTime.now().minusHours(1));
+
+        Buffer data = Buffer.buffer("{\n" +
+                "  \"requests\": [\n" +
+                "    {\n" +
+                "      \"uri\": \"/playground/some/url\",\n" +
+                "      \"method\": \"PUT\",\n" +
+                "      \"payload\": {\n" +
+                "        \"key\": 1\n" +
+                "      },\n" +
+                "      \"headers\": [[\"X-Client-Timestamp\", \"" + expiredClientTimestamp + "\"], [\"X-Expire-After\", \"1\"]]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}");
+
+        doAnswer(invocation -> {
+            Handler<Buffer> bodyHandler = invocation.getArgument(0);
+            bodyHandler.handle(data);
+            return request;
+        }).when(request).bodyHandler(any());
+
+        eventBus.consumer(redisquesAddress, message -> {
+            async.countDown();
+            message.reply(new JsonObject().put(STATUS, OK));
+        });
+
+        boolean handled = defaultPackingHandler.handle(request);
+        context.assertTrue(handled);
+
+        async.awaitSuccess();
     }
 
     @Test
@@ -479,6 +523,7 @@ public class PackingHandlerTest {
 
         assertSuccessMetricCounts(context, 1.0);
         assertFailMetricCounts(context, 0.0);
+        assertDropMetricCounts(context, 1.0);
     }
 
     private void assertSuccessMetricCounts(TestContext context, double expectedCount) {
@@ -489,5 +534,10 @@ public class PackingHandlerTest {
     private void assertFailMetricCounts(TestContext context, double expectedCount) {
         Counter counter = meterRegistry.get(PackingHandler.PACKING_REQUESTS_FAIL_COUNTER).counter();
         context.assertEquals(expectedCount, counter.count(), "Counter for failed packed requests should have been incremented by " + expectedCount);
+    }
+
+    private void assertDropMetricCounts(TestContext context, double expectedCount) {
+        Counter counter = meterRegistry.get(PackingHandler.PACKING_REQUESTS_DROP_COUNTER).counter();
+        context.assertEquals(expectedCount, counter.count(), "Counter for dropped packed requests should have been incremented by " + expectedCount);
     }
 }

--- a/gateleen-packing/src/test/java/org/swisspush/gateleen/packing/PackingHandlerTest.java
+++ b/gateleen-packing/src/test/java/org/swisspush/gateleen/packing/PackingHandlerTest.java
@@ -13,11 +13,13 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.swisspush.gateleen.core.exception.GateleenExceptionFactory;
+import org.swisspush.gateleen.core.util.ExpiryCheckHandler;
 import org.swisspush.gateleen.core.util.RoleExtractor;
 import org.swisspush.gateleen.core.util.StatusCode;
 import org.swisspush.gateleen.core.validation.ValidationResult;
@@ -376,6 +378,107 @@ public class PackingHandlerTest {
         assertFailMetricCounts(context, 0.0);
 
         async.awaitSuccess();
+    }
+
+    @Test
+    public void testHandleDropsExpiredRequest(TestContext context) throws InterruptedException {
+        when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap().add(PACK_HEADER, "true").add("x-rp-grp", "master"));
+        when(request.method()).thenReturn(HttpMethod.PUT);
+        when(validator.validatePackingPayload(any())).thenReturn(new ValidationResult(ValidationStatus.VALIDATED_POSITIV));
+
+        String expiredClientTimestamp = ExpiryCheckHandler.printDateTime(DateTime.now().minusHours(1));
+
+        Buffer data = Buffer.buffer("{\n" +
+                "  \"requests\": [\n" +
+                "    {\n" +
+                "      \"uri\": \"/playground/some/url\",\n" +
+                "      \"method\": \"PUT\",\n" +
+                "      \"payload\": {\n" +
+                "        \"key\": 1\n" +
+                "      },\n" +
+                "      \"headers\": [[\"X-Client-Timestamp\", \"" + expiredClientTimestamp + "\"], [\"X-Expire-After\", \"1\"]]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}");
+
+        doAnswer(invocation -> {
+            Handler<Buffer> bodyHandler = invocation.getArgument(0);
+            bodyHandler.handle(data);
+            return request;
+        }).when(request).bodyHandler(any());
+
+        eventBus.consumer(redisquesAddress, message -> {
+            context.fail("Expired request should not have been enqueued");
+        });
+
+        boolean handled = packingHandler.handle(request);
+        context.assertTrue(handled);
+
+        verify(response, times(1)).setStatusCode(eq(StatusCode.OK.getStatusCode()));
+        verify(response, times(1)).setStatusMessage(eq(StatusCode.OK.getStatusMessage()));
+        verify(validator, times(1)).validatePackingPayload(eq(data));
+
+        Thread.sleep(500);
+
+        assertSuccessMetricCounts(context, 0.0);
+        assertFailMetricCounts(context, 0.0);
+    }
+
+    @Test
+    public void testHandleDropsOnlyExpiredRequestsInMultiple(TestContext context) throws InterruptedException {
+        Async async = context.async(1);
+        when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap().add(PACK_HEADER, "true").add("x-rp-grp", "master"));
+        when(request.method()).thenReturn(HttpMethod.PUT);
+        when(validator.validatePackingPayload(any())).thenReturn(new ValidationResult(ValidationStatus.VALIDATED_POSITIV));
+
+        String expiredClientTimestamp = ExpiryCheckHandler.printDateTime(DateTime.now().minusHours(1));
+
+        Buffer data = Buffer.buffer("{\n" +
+                "  \"requests\": [\n" +
+                "    {\n" +
+                "      \"uri\": \"/playground/expired/url\",\n" +
+                "      \"method\": \"PUT\",\n" +
+                "      \"payload\": {\n" +
+                "        \"key\": 1\n" +
+                "      },\n" +
+                "      \"headers\": [[\"X-Client-Timestamp\", \"" + expiredClientTimestamp + "\"], [\"X-Expire-After\", \"1\"]]\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"uri\": \"/playground/valid/url\",\n" +
+                "      \"method\": \"PUT\",\n" +
+                "      \"payload\": {\n" +
+                "        \"key\": 2\n" +
+                "      },\n" +
+                "      \"headers\": [[\"x-bar\", \"foo\"]]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}");
+
+        doAnswer(invocation -> {
+            Handler<Buffer> bodyHandler = invocation.getArgument(0);
+            bodyHandler.handle(data);
+            return request;
+        }).when(request).bodyHandler(any());
+
+        eventBus.consumer(redisquesAddress, message -> {
+            async.countDown();
+            context.assertEquals("/playground/valid/url",
+                    new JsonObject(((JsonObject) message.body()).getString(MESSAGE)).getString("uri"));
+            message.reply(new JsonObject().put(STATUS, OK));
+        });
+
+        boolean handled = packingHandler.handle(request);
+        context.assertTrue(handled);
+
+        verify(response, times(1)).setStatusCode(eq(StatusCode.OK.getStatusCode()));
+        verify(response, times(1)).setStatusMessage(eq(StatusCode.OK.getStatusMessage()));
+        verify(validator, times(1)).validatePackingPayload(eq(data));
+
+        async.awaitSuccess();
+        Thread.sleep(500);
+
+        assertSuccessMetricCounts(context, 1.0);
+        assertFailMetricCounts(context, 0.0);
     }
 
     private void assertSuccessMetricCounts(TestContext context, double expectedCount) {

--- a/gateleen-packing/src/test/java/org/swisspush/gateleen/packing/PackingHandlerTest.java
+++ b/gateleen-packing/src/test/java/org/swisspush/gateleen/packing/PackingHandlerTest.java
@@ -414,8 +414,55 @@ public class PackingHandlerTest {
         boolean handled = packingHandler.handle(request);
         context.assertTrue(handled);
 
-        verify(response, times(1)).setStatusCode(eq(StatusCode.OK.getStatusCode()));
-        verify(response, times(1)).setStatusMessage(eq(StatusCode.OK.getStatusMessage()));
+        verify(response, times(1)).setStatusCode(eq(StatusCode.ACCEPTED.getStatusCode()));
+        verify(response, times(1)).setStatusMessage(eq(StatusCode.ACCEPTED.getStatusMessage()));
+        verify(validator, times(1)).validatePackingPayload(eq(data));
+
+        Thread.sleep(500);
+
+        assertSuccessMetricCounts(context, 0.0);
+        assertFailMetricCounts(context, 0.0);
+        assertDropMetricCounts(context, 1.0);
+    }
+
+    @Test
+    public void testHandleDropsExpiredRequestWithConfiguredStatus(TestContext context) throws InterruptedException {
+        PackingHandler customStatusPackingHandler = new PackingHandler(
+                vertx, queuePrefix, redisquesAddress, RoleExtractor.groupHeader, validator, exceptionFactory, false, StatusCode.REQUEST_TIMEOUT);
+        customStatusPackingHandler.setMeterRegistry(meterRegistry);
+
+        when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap().add(PACK_HEADER, "true").add("x-rp-grp", "master"));
+        when(request.method()).thenReturn(HttpMethod.PUT);
+        when(validator.validatePackingPayload(any())).thenReturn(new ValidationResult(ValidationStatus.VALIDATED_POSITIV));
+
+        String expiredClientTimestamp = ExpiryCheckHandler.printDateTime(DateTime.now().minusHours(1));
+
+        Buffer data = Buffer.buffer("{\n" +
+                "  \"requests\": [\n" +
+                "    {\n" +
+                "      \"uri\": \"/playground/some/url\",\n" +
+                "      \"method\": \"PUT\",\n" +
+                "      \"payload\": {\n" +
+                "        \"key\": 1\n" +
+                "      },\n" +
+                "      \"headers\": [[\"X-Client-Timestamp\", \"" + expiredClientTimestamp + "\"], [\"X-Expire-After\", \"1\"]]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}");
+
+        doAnswer(invocation -> {
+            Handler<Buffer> bodyHandler = invocation.getArgument(0);
+            bodyHandler.handle(data);
+            return request;
+        }).when(request).bodyHandler(any());
+
+        eventBus.consumer(redisquesAddress, message -> context.fail("Expired request should not have been enqueued"));
+
+        boolean handled = customStatusPackingHandler.handle(request);
+        context.assertTrue(handled);
+
+        verify(response, times(1)).setStatusCode(eq(StatusCode.REQUEST_TIMEOUT.getStatusCode()));
+        verify(response, times(1)).setStatusMessage(eq(StatusCode.REQUEST_TIMEOUT.getStatusMessage()));
         verify(validator, times(1)).validatePackingPayload(eq(data));
 
         Thread.sleep(500);

--- a/gateleen-queue/README_queue.md
+++ b/gateleen-queue/README_queue.md
@@ -12,9 +12,9 @@ Example values are:
 For now, only a retry count of `0` is supported. So the main use case for this feature are requests which should be tried once and then be discarded when not successful.
 
 ## Dropping expired requests
-Requests carrying an `X-Client-Timestamp` header (the timestamp set by the client when it originally issued the request) are checked for expiry before being enqueued. The expiration duration is taken from the `x-queue-expire-after` header, falling back to the `X-Expire-After` header when `x-queue-expire-after` is not present.
+Requests carrying an `X-Client-Timestamp` header (the timestamp set by the client when it originally issued the request) can be checked for expiry before being enqueued. The expiration duration is taken from the `x-queue-expire-after` header, falling back to the `X-Expire-After` header when `x-queue-expire-after` is not present.
 
-If the time elapsed between the `X-Client-Timestamp` and now exceeds the configured expire-after value, the request is considered expired and is dropped instead of being enqueued. Requests without an `X-Client-Timestamp` header, or with a value that cannot be parsed, are never considered expired.
+If the time elapsed between the `X-Client-Timestamp` and now exceeds the configured expire-after value, the request is considered expired. Expired requests are dropped only when `QueuingHandler`/`PackingHandler` is configured with `enqueueExpiredRequest = false`; otherwise they are still enqueued. Requests without an `X-Client-Timestamp` header, or with a value that cannot be parsed, are never considered expired.
 
 This check is performed by `QueuingHandler.isRequestExpired(MultiMap)` and is applied both when a request is queued directly (`QueuingHandler`) and when unpacking requests from a packed payload (`PackingHandler`). When multiple requests are unpacked together, only the expired ones are dropped - the remaining, non-expired requests are still enqueued normally.
 

--- a/gateleen-queue/README_queue.md
+++ b/gateleen-queue/README_queue.md
@@ -11,6 +11,20 @@ Example values are:
 ```
 For now, only a retry count of `0` is supported. So the main use case for this feature are requests which should be tried once and then be discarded when not successful.
 
+## Dropping expired requests
+Requests carrying an `X-Client-Timestamp` header (the timestamp set by the client when it originally issued the request) are checked for expiry before being enqueued. The expiration duration is taken from the `x-queue-expire-after` header, falling back to the `X-Expire-After` header when `x-queue-expire-after` is not present.
+
+If the time elapsed between the `X-Client-Timestamp` and now exceeds the configured expire-after value, the request is considered expired and is silently dropped instead of being enqueued. Requests without an `X-Client-Timestamp` header, or with a value that cannot be parsed, are never considered expired.
+
+This check is performed by `QueuingHandler.isRequestExpired(MultiMap)` and is applied both when a request is queued directly (`QueuingHandler`) and when unpacking requests from a packed payload (`PackingHandler`). When multiple requests are unpacked together, only the expired ones are dropped - the remaining, non-expired requests are still enqueued normally.
+
+Example headers:
+```
+"X-Client-Timestamp": "2020-03-05T10:21:27.021+01:00"
+"x-queue-expire-after": "60"
+```
+In the example above, the request expires 60 seconds after `2020-03-05T10:21:27.021+01:00`.
+
 ## Queue Circuit Breaker
 The Queue Circuit Breaker hereinafter referred to as **QCB** can be used to protect your server from having to deal with lots of queued requests when a backend is not reachable.
 

--- a/gateleen-queue/README_queue.md
+++ b/gateleen-queue/README_queue.md
@@ -14,9 +14,11 @@ For now, only a retry count of `0` is supported. So the main use case for this f
 ## Dropping expired requests
 Requests carrying an `X-Client-Timestamp` header (the timestamp set by the client when it originally issued the request) are checked for expiry before being enqueued. The expiration duration is taken from the `x-queue-expire-after` header, falling back to the `X-Expire-After` header when `x-queue-expire-after` is not present.
 
-If the time elapsed between the `X-Client-Timestamp` and now exceeds the configured expire-after value, the request is considered expired and is silently dropped instead of being enqueued. Requests without an `X-Client-Timestamp` header, or with a value that cannot be parsed, are never considered expired.
+If the time elapsed between the `X-Client-Timestamp` and now exceeds the configured expire-after value, the request is considered expired and is dropped instead of being enqueued. Requests without an `X-Client-Timestamp` header, or with a value that cannot be parsed, are never considered expired.
 
 This check is performed by `QueuingHandler.isRequestExpired(MultiMap)` and is applied both when a request is queued directly (`QueuingHandler`) and when unpacking requests from a packed payload (`PackingHandler`). When multiple requests are unpacked together, only the expired ones are dropped - the remaining, non-expired requests are still enqueued normally.
+
+When an expired request is dropped by `QueuingHandler`, the HTTP response status defaults to `202 Accepted`. This can be overridden by using the constructor overload that accepts a `StatusCode expiredRequestStatusCode` parameter.
 
 Example headers:
 ```

--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueuingHandler.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueuingHandler.java
@@ -45,6 +45,7 @@ public class QueuingHandler implements Handler<Buffer> {
     private final RedisProvider redisProvider;
     private final QueueSplitter queueSplitter;
     private final boolean enqueueExpiredRequest;
+    private final StatusCode expiredRequestStatusCode;
 
     public QueuingHandler(
             Vertx vertx,
@@ -62,12 +63,25 @@ public class QueuingHandler implements Handler<Buffer> {
             @Nullable MonitoringHandler monitoringHandler,
             QueueSplitter queueSplitter
     ) {
+        this(vertx, redisProvider, request, monitoringHandler, queueSplitter, StatusCode.ACCEPTED);
+    }
+
+    public QueuingHandler(
+            Vertx vertx,
+            RedisProvider redisProvider,
+            HttpServerRequest request,
+            @Nullable MonitoringHandler monitoringHandler,
+            QueueSplitter queueSplitter,
+            StatusCode expiredRequestStatusCode
+    ) {
         this(
                 vertx,
                 redisProvider,
                 request,
                 new QueueClient(vertx, monitoringHandler),
-                queueSplitter == null ? new NoOpQueueSplitter() : queueSplitter
+                queueSplitter == null ? new NoOpQueueSplitter() : queueSplitter,
+                true,
+                expiredRequestStatusCode
         );
     }
 
@@ -89,12 +103,25 @@ public class QueuingHandler implements Handler<Buffer> {
             QueueSplitter queueSplitter,
             boolean enqueueExpiredRequest
     ) {
+        this(vertx, redisProvider, request, requestQueue, queueSplitter, enqueueExpiredRequest, StatusCode.ACCEPTED);
+    }
+
+    public QueuingHandler(
+            Vertx vertx,
+            RedisProvider redisProvider,
+            HttpServerRequest request,
+            RequestQueue requestQueue,
+            QueueSplitter queueSplitter,
+            boolean enqueueExpiredRequest,
+            StatusCode expiredRequestStatusCode
+    ) {
         this.request = request;
         this.vertx = vertx;
         this.redisProvider = redisProvider;
         this.requestQueue = requestQueue;
         this.queueSplitter = queueSplitter;
         this.enqueueExpiredRequest = enqueueExpiredRequest;
+        this.expiredRequestStatusCode = expiredRequestStatusCode == null ? StatusCode.ACCEPTED : expiredRequestStatusCode;
     }
 
     @Override
@@ -105,8 +132,8 @@ public class QueuingHandler implements Handler<Buffer> {
         if (!enqueueExpiredRequest && isRequestExpired(headers)) {
             // just skip this request, because the queue already expired
             log.info("Dropping expired queued request '{}'", request.uri());
-            request.response().setStatusCode(StatusCode.ACCEPTED.getStatusCode());
-            request.response().setStatusMessage(StatusCode.ACCEPTED.getStatusMessage());
+            request.response().setStatusCode(expiredRequestStatusCode.getStatusCode());
+            request.response().setStatusMessage(expiredRequestStatusCode.getStatusMessage());
             request.response().end();
             return;
         }

--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueuingHandler.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueuingHandler.java
@@ -6,6 +6,8 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.swisspush.gateleen.core.redis.RedisProvider;
 import org.swisspush.gateleen.core.util.Address;
 import org.swisspush.gateleen.core.util.ExpiryCheckHandler;
@@ -25,7 +27,7 @@ import static org.swisspush.redisques.util.RedisquesAPI.buildCheckOperation;
  * @author https://github.com/lbovet [Laurent Bovet]
  */
 public class QueuingHandler implements Handler<Buffer> {
-
+    private Logger log = LoggerFactory.getLogger(QueuingHandler.class);
     public static final String QUEUE_HEADER = "x-queue";
     public static final String ORIGINALLY_QUEUED_HEADER = "x-originally-queued";
     public static final String DUPLICATE_CHECK_HEADER = "x-duplicate-check";
@@ -76,7 +78,7 @@ public class QueuingHandler implements Handler<Buffer> {
             RequestQueue requestQueue,
             QueueSplitter queueSplitter
     ) {
-        this(vertx, redisProvider, request, requestQueue, queueSplitter, false);
+        this(vertx, redisProvider, request, requestQueue, queueSplitter, true);
     }
 
     public QueuingHandler(
@@ -102,6 +104,7 @@ public class QueuingHandler implements Handler<Buffer> {
 
         if (!enqueueExpiredRequest && isRequestExpired(headers)) {
             // just skip this request, because the queue already expired
+            log.info("Dropping expired queued request '{}'", request.uri());
             request.response().setStatusCode(StatusCode.ACCEPTED.getStatusCode());
             request.response().setStatusMessage(StatusCode.ACCEPTED.getStatusMessage());
             request.response().end();

--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueuingHandler.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueuingHandler.java
@@ -8,6 +8,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import org.swisspush.gateleen.core.redis.RedisProvider;
 import org.swisspush.gateleen.core.util.Address;
+import org.swisspush.gateleen.core.util.ExpiryCheckHandler;
 import org.swisspush.gateleen.core.util.StatusCode;
 import org.swisspush.gateleen.monitoring.MonitoringHandler;
 import org.swisspush.gateleen.queue.duplicate.DuplicateCheckHandler;
@@ -28,6 +29,7 @@ public class QueuingHandler implements Handler<Buffer> {
     public static final String QUEUE_HEADER = "x-queue";
     public static final String ORIGINALLY_QUEUED_HEADER = "x-originally-queued";
     public static final String DUPLICATE_CHECK_HEADER = "x-duplicate-check";
+    public static final String CLIENT_TIMESTAMP_HEADER = "X-Client-Timestamp";
 
     private final RequestQueue requestQueue;
 
@@ -40,6 +42,7 @@ public class QueuingHandler implements Handler<Buffer> {
     private final Vertx vertx;
     private final RedisProvider redisProvider;
     private final QueueSplitter queueSplitter;
+    private final boolean enqueueExpiredRequest;
 
     public QueuingHandler(
             Vertx vertx,
@@ -73,17 +76,38 @@ public class QueuingHandler implements Handler<Buffer> {
             RequestQueue requestQueue,
             QueueSplitter queueSplitter
     ) {
+        this(vertx, redisProvider, request, requestQueue, queueSplitter, false);
+    }
+
+    public QueuingHandler(
+            Vertx vertx,
+            RedisProvider redisProvider,
+            HttpServerRequest request,
+            RequestQueue requestQueue,
+            QueueSplitter queueSplitter,
+            boolean enqueueExpiredRequest
+    ) {
         this.request = request;
         this.vertx = vertx;
         this.redisProvider = redisProvider;
         this.requestQueue = requestQueue;
         this.queueSplitter = queueSplitter;
+        this.enqueueExpiredRequest = enqueueExpiredRequest;
     }
 
     @Override
     public void handle(final Buffer buffer) {
         final String queue = request.headers().get(QUEUE_HEADER);
         final MultiMap headers = request.headers();
+
+        if (!enqueueExpiredRequest && isRequestExpired(headers)) {
+            // just skip this request, because the queue already expired
+            request.response().setStatusCode(StatusCode.ACCEPTED.getStatusCode());
+            request.response().setStatusMessage(StatusCode.ACCEPTED.getStatusMessage());
+            request.response().end();
+            return;
+        }
+
         // Remove the queue header to avoid feedback loop
         headers.remove(QUEUE_HEADER);
 
@@ -104,6 +128,33 @@ public class QueuingHandler implements Handler<Buffer> {
 
         } else {
             requestQueue.enqueue(request, headers, buffer, queueSplitter.convertToSubQueue(queue, request));
+        }
+    }
+
+    /**
+     * Checks whether the request has expired based on the "X-Client-Timestamp" header
+     * (the moment the client originally sent the request) together with the
+     * "x-queue-expire-after" (or "X-Expire-After") header defining how long the request
+     * is valid for.
+     *
+     * @param headers the request headers
+     * @return true if the request has expired, false otherwise (also if no client
+     * timestamp is present or its value can't be parsed)
+     */
+    public static boolean isRequestExpired(MultiMap headers) {
+        if (headers == null || headers.isEmpty()) {
+            return false;
+        }
+        String clientTimestamp = headers.get(CLIENT_TIMESTAMP_HEADER);
+        if (clientTimestamp == null) {
+            return false;
+        }
+        try {
+            long timestamp = ExpiryCheckHandler.parseDateTime(clientTimestamp).getMillis();
+            return ExpiryCheckHandler.isExpired(headers, timestamp);
+        } catch (IllegalArgumentException e) {
+            // invalid/unparseable timestamp, treat request as not expired
+            return false;
         }
     }
 

--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueuingHandler.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueuingHandler.java
@@ -19,6 +19,7 @@ import org.swisspush.gateleen.queue.queuing.splitter.QueueSplitter;
 
 import javax.annotation.Nullable;
 
+import static org.swisspush.gateleen.core.util.ExpiryCheckHandler.CLIENT_TIMESTAMP_HEADER;
 import static org.swisspush.redisques.util.RedisquesAPI.buildCheckOperation;
 
 /**
@@ -27,11 +28,10 @@ import static org.swisspush.redisques.util.RedisquesAPI.buildCheckOperation;
  * @author https://github.com/lbovet [Laurent Bovet]
  */
 public class QueuingHandler implements Handler<Buffer> {
-    private Logger log = LoggerFactory.getLogger(QueuingHandler.class);
+    private static final Logger log = LoggerFactory.getLogger(QueuingHandler.class);
     public static final String QUEUE_HEADER = "x-queue";
     public static final String ORIGINALLY_QUEUED_HEADER = "x-originally-queued";
     public static final String DUPLICATE_CHECK_HEADER = "x-duplicate-check";
-    public static final String CLIENT_TIMESTAMP_HEADER = "X-Client-Timestamp";
 
     private final RequestQueue requestQueue;
 
@@ -172,7 +172,7 @@ public class QueuingHandler implements Handler<Buffer> {
      * timestamp is present or its value can't be parsed)
      */
     public static boolean isRequestExpired(MultiMap headers) {
-        if (headers == null || headers.isEmpty()) {
+        if (headers == null) {
             return false;
         }
         String clientTimestamp = headers.get(CLIENT_TIMESTAMP_HEADER);

--- a/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/queuing/QueuingHandlerTest.java
+++ b/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/queuing/QueuingHandlerTest.java
@@ -1,0 +1,88 @@
+package org.swisspush.gateleen.queue.queuing;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.swisspush.gateleen.core.util.ExpiryCheckHandler;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link QueuingHandler#isRequestExpired(MultiMap)} method.
+ */
+public class QueuingHandlerTest {
+
+    private static final String CLIENT_TIMESTAMP_HEADER = "X-Client-Timestamp";
+    private static final String EXPIRE_AFTER_HEADER = "X-Expire-After";
+    private static final String QUEUE_EXPIRE_AFTER_HEADER = "x-queue-expire-after";
+
+    @Test
+    public void isRequestExpired_returnsFalseWhenHeadersAreNull() {
+        assertFalse(QueuingHandler.isRequestExpired(null));
+    }
+
+    @Test
+    public void isRequestExpired_returnsFalseWhenClientTimestampHeaderIsMissing() {
+        MultiMap headers = new HeadersMultiMap();
+        headers.set(EXPIRE_AFTER_HEADER, "1");
+
+        assertFalse(QueuingHandler.isRequestExpired(headers));
+    }
+
+    @Test
+    public void isRequestExpired_returnsFalseWhenClientTimestampIsNotParseable() {
+        MultiMap headers = new HeadersMultiMap();
+        headers.set(CLIENT_TIMESTAMP_HEADER, "not-a-valid-timestamp");
+        headers.set(EXPIRE_AFTER_HEADER, "1");
+
+        assertFalse(QueuingHandler.isRequestExpired(headers));
+    }
+
+    @Test
+    public void isRequestExpired_returnsFalseWhenNoExpireHeadersArePresent() {
+        MultiMap headers = new HeadersMultiMap();
+        headers.set(CLIENT_TIMESTAMP_HEADER, ExpiryCheckHandler.printDateTime(DateTime.now().minusHours(1)));
+
+        assertFalse(QueuingHandler.isRequestExpired(headers));
+    }
+
+    @Test
+    public void isRequestExpired_returnsTrueWhenExpireAfterElapsedSinceClientTimestamp() {
+        MultiMap headers = new HeadersMultiMap();
+        headers.set(CLIENT_TIMESTAMP_HEADER, ExpiryCheckHandler.printDateTime(DateTime.now().minusSeconds(10)));
+        headers.set(EXPIRE_AFTER_HEADER, "1");
+
+        assertTrue(QueuingHandler.isRequestExpired(headers));
+    }
+
+    @Test
+    public void isRequestExpired_returnsFalseWhenExpireAfterNotYetElapsedSinceClientTimestamp() {
+        MultiMap headers = new HeadersMultiMap();
+        headers.set(CLIENT_TIMESTAMP_HEADER, ExpiryCheckHandler.printDateTime(DateTime.now()));
+        headers.set(EXPIRE_AFTER_HEADER, "3600");
+
+        assertFalse(QueuingHandler.isRequestExpired(headers));
+    }
+
+    @Test
+    public void isRequestExpired_queueExpireAfterOverridesExpireAfter() {
+        MultiMap headers = new HeadersMultiMap();
+        // X-Expire-After alone would NOT be expired yet, but x-queue-expire-after overrides it and IS expired
+        headers.set(CLIENT_TIMESTAMP_HEADER, ExpiryCheckHandler.printDateTime(DateTime.now().minusSeconds(10)));
+        headers.set(EXPIRE_AFTER_HEADER, "3600");
+        headers.set(QUEUE_EXPIRE_AFTER_HEADER, "1");
+
+        assertTrue(QueuingHandler.isRequestExpired(headers));
+    }
+
+    @Test
+    public void isRequestExpired_returnsFalseWhenExpireAfterIsInfinite() {
+        MultiMap headers = new HeadersMultiMap();
+        headers.set(CLIENT_TIMESTAMP_HEADER, ExpiryCheckHandler.printDateTime(DateTime.now().minusHours(1)));
+        headers.set(EXPIRE_AFTER_HEADER, "-1");
+
+        assertFalse(QueuingHandler.isRequestExpired(headers));
+    }
+}

--- a/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/queuing/QueuingHandlerTest.java
+++ b/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/queuing/QueuingHandlerTest.java
@@ -8,15 +8,14 @@ import org.swisspush.gateleen.core.util.ExpiryCheckHandler;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.swisspush.gateleen.core.util.ExpiryCheckHandler.EXPIRE_AFTER_HEADER;
+import static org.swisspush.gateleen.core.util.ExpiryCheckHandler.QUEUE_EXPIRE_AFTER_HEADER;
+import static org.swisspush.gateleen.queue.queuing.QueuingHandler.CLIENT_TIMESTAMP_HEADER;
 
 /**
  * Tests for the {@link QueuingHandler#isRequestExpired(MultiMap)} method.
  */
 public class QueuingHandlerTest {
-
-    private static final String CLIENT_TIMESTAMP_HEADER = "X-Client-Timestamp";
-    private static final String EXPIRE_AFTER_HEADER = "X-Expire-After";
-    private static final String QUEUE_EXPIRE_AFTER_HEADER = "x-queue-expire-after";
 
     @Test
     public void isRequestExpired_returnsFalseWhenHeadersAreNull() {

--- a/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/queuing/QueuingHandlerTest.java
+++ b/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/queuing/QueuingHandlerTest.java
@@ -1,12 +1,24 @@
 package org.swisspush.gateleen.queue.queuing;
 
 import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import org.joda.time.DateTime;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.swisspush.gateleen.core.http.DummyHttpServerRequest;
+import org.swisspush.gateleen.core.http.DummyHttpServerResponse;
+import org.swisspush.gateleen.core.redis.RedisProvider;
 import org.swisspush.gateleen.core.util.ExpiryCheckHandler;
+import org.swisspush.gateleen.core.util.StatusCode;
+import org.swisspush.gateleen.queue.queuing.splitter.NoOpQueueSplitter;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.swisspush.gateleen.core.util.ExpiryCheckHandler.EXPIRE_AFTER_HEADER;
 import static org.swisspush.gateleen.core.util.ExpiryCheckHandler.QUEUE_EXPIRE_AFTER_HEADER;
@@ -83,5 +95,82 @@ public class QueuingHandlerTest {
         headers.set(EXPIRE_AFTER_HEADER, "-1");
 
         assertFalse(QueuingHandler.isRequestExpired(headers));
+    }
+
+    @Test
+    public void handle_expiredRequestReturnsAcceptedByDefault() {
+        DummyHttpServerResponse response = new DummyHttpServerResponse();
+        HeadersMultiMap headers = expiredQueueHeaders();
+        RequestQueue requestQueue = Mockito.mock(RequestQueue.class);
+
+        QueuingHandler handler = new QueuingHandler(
+                (Vertx) null,
+                Mockito.mock(RedisProvider.class),
+                requestWith(headers, response),
+                requestQueue,
+                new NoOpQueueSplitter(),
+                false
+        );
+
+        handler.handle(Buffer.buffer("ignored"));
+
+        assertEquals(StatusCode.ACCEPTED.getStatusCode(), response.getStatusCode());
+        assertEquals(StatusCode.ACCEPTED.getStatusMessage(), response.getStatusMessage());
+        Mockito.verifyNoInteractions(requestQueue);
+    }
+
+    @Test
+    public void handle_expiredRequestReturnsConfiguredStatusCode() {
+        DummyHttpServerResponse response = new DummyHttpServerResponse();
+        HeadersMultiMap headers = expiredQueueHeaders();
+        RequestQueue requestQueue = Mockito.mock(RequestQueue.class);
+
+        QueuingHandler handler = new QueuingHandler(
+                (Vertx) null,
+                Mockito.mock(RedisProvider.class),
+                requestWith(headers, response),
+                requestQueue,
+                new NoOpQueueSplitter(),
+                false,
+                StatusCode.REQUEST_TIMEOUT
+        );
+
+        handler.handle(Buffer.buffer("ignored"));
+
+        assertEquals(StatusCode.REQUEST_TIMEOUT.getStatusCode(), response.getStatusCode());
+        assertEquals(StatusCode.REQUEST_TIMEOUT.getStatusMessage(), response.getStatusMessage());
+        Mockito.verifyNoInteractions(requestQueue);
+    }
+
+    private HeadersMultiMap expiredQueueHeaders() {
+        HeadersMultiMap headers = new HeadersMultiMap();
+        headers.set(QueuingHandler.QUEUE_HEADER, "my-queue");
+        headers.set(CLIENT_TIMESTAMP_HEADER, ExpiryCheckHandler.printDateTime(DateTime.now().minusSeconds(10)));
+        headers.set(EXPIRE_AFTER_HEADER, "1");
+        return headers;
+    }
+
+    private HttpServerRequest requestWith(HeadersMultiMap headers, DummyHttpServerResponse response) {
+        return new DummyHttpServerRequest() {
+            @Override
+            public MultiMap headers() {
+                return headers;
+            }
+
+            @Override
+            public HttpMethod method() {
+                return HttpMethod.PUT;
+            }
+
+            @Override
+            public String uri() {
+                return "/resources/my-resource";
+            }
+
+            @Override
+            public HttpServerResponse response() {
+                return response;
+            }
+        };
     }
 }

--- a/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/queuing/QueuingHandlerTest.java
+++ b/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/queuing/QueuingHandlerTest.java
@@ -20,9 +20,9 @@ import org.swisspush.gateleen.queue.queuing.splitter.NoOpQueueSplitter;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.swisspush.gateleen.core.util.ExpiryCheckHandler.CLIENT_TIMESTAMP_HEADER;
 import static org.swisspush.gateleen.core.util.ExpiryCheckHandler.EXPIRE_AFTER_HEADER;
 import static org.swisspush.gateleen.core.util.ExpiryCheckHandler.QUEUE_EXPIRE_AFTER_HEADER;
-import static org.swisspush.gateleen.queue.queuing.QueuingHandler.CLIENT_TIMESTAMP_HEADER;
 
 /**
  * Tests for the {@link QueuingHandler#isRequestExpired(MultiMap)} method.


### PR DESCRIPTION
Requests carrying an `X-Client-Timestamp` header (the timestamp set by the client when it originally issued the request) are checked for expiry before being enqueued. The expiration duration is taken from the `x-queue-expire-after` header, falling back to the `X-Expire-After` header when `x-queue-expire-after` is not present.